### PR TITLE
Filter station

### DIFF
--- a/src/process_packet.rs
+++ b/src/process_packet.rs
@@ -337,7 +337,7 @@ fn usize_to_u8(a: usize) -> Option<u8> {
 ///
 /// # Examples
 ///
-/// ```
+/// ```compile_fail
 /// let flow_src_station = String::from("192.122.200.231");
 /// let flow_src_client = String::from("128.138.89.172");
 /// 
@@ -367,3 +367,18 @@ fn filter_station_traffic(src: String) -> Option<()> {
     Some(())
 }
 
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_filter_station_traffic() {
+        let flow_src_station = String::from("192.122.200.231");
+        let flow_src_client = String::from("128.138.89.172");
+        
+        let station = super::filter_station_traffic(flow_src_station);
+        let client = super::filter_station_traffic(flow_src_client);
+        
+        assert_eq!(None, station);
+        assert_eq!(Some(()), client);
+    }
+}


### PR DESCRIPTION
Filter out liveness traffic from all stations as they just add logs in detector and application (though they will fail min-transport in application so they don't really hurt anything too much). 

Note: this will prevent tunneling of conjure connections over conjure connections If we attempt that in the near future.