### PR TITLE
Add checks for UDP probe packets

### DIFF
--- a/src/flow_tracker.rs
+++ b/src/flow_tracker.rs
@@ -6,6 +6,7 @@ use redis;
 
 use std::net::IpAddr;
 use pnet::packet::tcp::TcpPacket;
+use pnet::packet::udp::UdpPacket;
 
 use util::IpPacket;
 use std::fmt;
@@ -46,6 +47,25 @@ impl Flow
             },
         }
     }
+
+    pub fn new_udp(ip_pkt: &IpPacket, udp_pkt: &UdpPacket) -> Flow
+    {
+        match ip_pkt {
+            IpPacket::V4(pkt) => Flow {
+                src_ip: IpAddr::V4(pkt.get_source()),
+                dst_ip: IpAddr::V4(pkt.get_destination()),
+                src_port: udp_pkt.get_source(),
+                dst_port: udp_pkt.get_destination(),
+            },
+            IpPacket::V6(pkt) => Flow {
+                src_ip: IpAddr::V6(pkt.get_source()),
+                dst_ip: IpAddr::V6(pkt.get_destination()),
+                src_port: udp_pkt.get_source(),
+                dst_port: udp_pkt.get_destination(),
+            },
+        }
+    }
+
     pub fn from_parts(sip: IpAddr, dip: IpAddr, sport: u16, dport: u16) -> Flow
     {
         Flow { src_ip: sip, dst_ip: dip, src_port: sport, dst_port: dport }

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,6 +11,7 @@ use std::error::Error;
 
 use pnet::packet::Packet;
 use pnet::packet::tcp::{TcpOptionNumbers, TcpPacket};
+use pnet::packet::udp::UdpPacket;
 use pnet::packet::ipv4::Ipv4Packet;
 use pnet::packet::ipv6::Ipv6Packet;
 
@@ -27,6 +28,14 @@ impl<'p> IpPacket<'p> {
             IpPacket::V6(v6) => v6.payload(),
         };
         TcpPacket::new(payload)
+    }
+
+    pub fn udp(&'p self) -> Option<UdpPacket<'p>> {
+        let payload = match self {
+            IpPacket::V4(v4) => v4.payload(),
+            IpPacket::V6(v6) => v6.payload(),
+        };
+        UdpPacket::new(payload)
     }
 }
 


### PR DESCRIPTION
This PR adds the ability for the detector to look for special UDP packets sent as DNS requests for a certain domain, used for routing research. The detector only examines UDP packets sent to port 53, and only does any comparisons if the UDP payload is at least `SPECIAL_UDP_PAYLOAD.len()` bytes long (`windows` will return an iterator with no values otherwise), which is rare for a DNS packet. While it would have been possible to bring in a DNS parsing library as well, given that our packets are abnormal enough to scrap most DNS packets before doing any parsing and most slice comparisons will return early after the first byte not matching, I felt like it was simpler to just look for the payload in the UDP payload itself.