### PR TITLE
Added build CI pipeline action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
         with:
-          path: '$HOME/go/src/github.com/refraction-networking/conjure'
-          submodules: 'recursive'
+          path: ${HOME}/go/src/github.com/refraction-networking/
+          submodules: recursive
         
       # Build the conjure station
       - name: Install Conjure build dependencies 
@@ -34,22 +34,25 @@ jobs:
           sudo apt-get update
           sudo apt-get install protobuf-compiler gcc curl git wget -y -q
           sudo apt-get install libzmq3-dev redis-server libssl-dev pkg-config libgmp3-dev -y -q
-          echo "Apt dependencies installed\n--------------------------------------"
+          echo "Apt dependencies installed"
+          echo "--------------------------------------"
           
           # Build PF_Ring libraries
-          ls
+          ls -la .
           ls PF_RING
           cd PF_RING/userland/lib && ./configure && make
           cd PF_RING/userland/libpcap && ./configure && make
-          echo "PF_Ring libraries successfully built\n--------------------------------------"
-          
+          echo "PF_Ring libraries successfully built"
+          echo "--------------------------------------"
+
           # Install rust
           curl https://sh.rustup.rs -sSf -o install_rust.sh; sh install_rust.sh -y;          
           cargo install protobuf-codegen
           export PATH=$PATH:$HOME/.cargo/bin
           source $HOME/.cargo/env
-          echo "Rust successfully installed\n--------------------------------------"
-          
+          echo "Rust successfully installed"
+          echo "--------------------------------------"
+
           # Install Golang
           sudo rm -rf /usr/local/go
           wget -q https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
@@ -64,8 +67,9 @@ jobs:
           go get -u github.com/BurntSushi/toml || true
           go get -u github.com/refraction-networking/conjure/application/... || true 
           go get -u github.com/refraction-networking/conjure/registration-api/... || true 
-          echo "Golang and go dependencies successfully installed\n--------------------------------------"
-    
+          echo "Golang and go dependencies successfully installed"
+          echo "--------------------------------------"
+
           # Build it
           make
           echo "Station successfully built"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,18 +30,24 @@ jobs:
           # RUSTVERSION: 1.47.0
         run: |
           # Apt deps
+          pwd
           sudo apt-get update
           sudo apt-get install protobuf-compiler gcc curl git wget -y -q
           sudo apt-get install libzmq3-dev redis-server libssl-dev pkg-config libgmp3-dev -y -q
+          echo "Apt dependencies installed"
           
           # Build PF_Ring libraries
           cd PF_RING/userland/lib && ./configure && make
           cd PF_RING/userland/libpcap && ./configure && make
+          pwd
+          echo "PF_Ring libraries successfully built"
           
           # Install rust
           curl https://sh.rustup.rs -sSf -o install_rust.sh; sh install_rust.sh -y;          
           cargo install protobuf-codegen
           export PATH=$PATH:$HOME/.cargo/bin
+          source $HOME/.cargo/env
+          echo "Rust successfully installed"
           
           # Install Golang
           wget -q https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
@@ -55,9 +61,12 @@ jobs:
           go get -u github.com/go-redis/redis || true && cd /root/go/src/github.com/go-redis/redis && git checkout tags/v7.4.0 -b v7-master
           go get -u github.com/BurntSushi/toml || true
           go get -u github.com/refraction-networking/conjure/... || true 
-          
+          echo "Golang and go dependencies successfully installed"
+    
           # Build it
           make
+          echo "Station successfully built"
+
       
       - name: Save Build artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,9 @@ jobs:
           GO_VERSION: 1.15.4
           # RUSTVERSION: 1.47.0
         run: |
-          ls -la
+          cd go/src/github.com/refraction-networking/conjure
+          
           # Apt deps
-          pwd
           sudo apt-get update
           sudo apt-get install protobuf-compiler gcc curl git wget -y -q
           sudo apt-get install libzmq3-dev redis-server libssl-dev pkg-config libgmp3-dev -y -q

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
           GO_VERSION: 1.15.4
           # RUSTVERSION: 1.47.0
         run: |
+          echo "HOME=$HOME"
           export GOPATH=`pwd`/go
           echo "GOPATH=$GOPATH"
           cd go/src/github.com/refraction-networking/conjure
@@ -36,13 +37,11 @@ jobs:
           # Apt deps
           sudo apt-get update
           sudo apt-get install protobuf-compiler gcc curl git wget -y -q
-          sudo apt-get install libzmq3-dev redis-server libssl-dev pkg-config libgmp3-dev -y -q
+          sudo apt-get install libzmq3-dev libssl-dev pkg-config libgmp3-dev -y -q
           echo "Apt dependencies installed"
           echo "--------------------------------------"
           
           # Build PF_Ring libraries
-          ls -la .
-          ls PF_RING
           cd PF_RING/userland/lib && ./configure && make
           cd PF_RING/userland/libpcap && ./configure && make
           echo "PF_Ring libraries successfully built"
@@ -63,8 +62,9 @@ jobs:
           export PATH=$PATH:/usr/local/go/bin
           export GOROOT="/usr/local/go"
           go version
+          which go
           # temp fix before transition to redis v8
-          go get -u github.com/go-redis/redis || true && cd $GOPATH/src/github.com/go-redis/redis && git checkout tags/v7.4.0 -b v7-master
+          # go get -u github.com/go-redis/redis || true && cd $GOPATH/src/github.com/go-redis/redis && git checkout tags/v7.4.0 -b v7-master
           go get -u github.com/BurntSushi/toml || true
           go get -u github.com/refraction-networking/conjure/application/... || true 
           go get -u github.com/refraction-networking/conjure/registration-api/... || true 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           GO_VERSION: 1.15.4
           # RUSTVERSION: 1.47.0
         run: |
-          cd $HOME/go/src/github.com/refraction-networking/
+          ls -la
           # Apt deps
           pwd
           sudo apt-get update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
         with:
-          path: ${HOME}/go/src/github.com/refraction-networking/
+          path: $HOME/go/src/github.com/refraction-networking/
           submodules: recursive
         
       # Build the conjure station
@@ -29,6 +29,7 @@ jobs:
           GO_VERSION: 1.15.4
           # RUSTVERSION: 1.47.0
         run: |
+          cd $HOME/go/src/github.com/refraction-networking/
           # Apt deps
           pwd
           sudo apt-get update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           submodules: recursive
         
       # Build the conjure station
-      - name: Install Conjure build dependencies 
+      - name: Install Conjure build dependencies and Build Station Elements
         env: 
           GO_VERSION: 1.15.4
           # RUSTVERSION: 1.47.0
@@ -63,10 +63,8 @@ jobs:
           export PATH=$PATH:/usr/local/go/bin
           export GOROOT="/usr/local/go"
           go version
-          which go
           # temp fix before transition to redis v8
           go get -u github.com/go-redis/redis || true && cd $GOPATH/src/github.com/go-redis/redis && git checkout tags/v7.4.0 -b v7-master && cd -
-          pwd
           go get -u github.com/BurntSushi/toml || true
           go get -d -u -t github.com/refraction-networking/gotapdance/... || true
           go get -u github.com/refraction-networking/conjure/application/... || true 
@@ -75,10 +73,10 @@ jobs:
           echo "--------------------------------------"
 
           # Build it
-          pwd
           cd $GOPATH/src/github.com/refraction-networking/conjure
-          make
           echo "Station successfully built"
+          cp dark-decoy application/application registration-api/registration-api $GITHUB_WORKSPACE
+          
 
       
       - name: Save Build artifacts
@@ -86,6 +84,6 @@ jobs:
         with:
           path: |
             dark-decoy
-            application/application
-            registration-api/registration-api
+            application
+            registration-api
             

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Save Build artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ github.ref }}/conjure-station
+          name: conjure-station.tar.gz
           path: |
             conjure-station.tar.gz
             

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,7 @@ jobs:
 
           # Build it
           cd $GOPATH/src/github.com/refraction-networking/conjure
+          make
           echo "Station successfully built"
           cp dark-decoy application/application registration-api/registration-api $GITHUB_WORKSPACE
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,13 +78,13 @@ jobs:
           echo "Station successfully built"
           mkdir -p  $GITHUB_WORKSPACE/bin
           cp dark-decoy application/application registration-api/registration-api $GITHUB_WORKSPACE/bin
-          cd $GITHUB_WORKSPACE && tar -czf conjure-station_${{ github.ref }}.tar.gz bin
+          cd $GITHUB_WORKSPACE && tar -czf conjure-station.tar.gz bin
           
       
       - name: Save Build artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: conjure-${{ github.ref }}
+          name: ${{ github.ref }}/conjure-station
           path: |
-            conjure-station_${{ github.ref }}.tar.gz
+            conjure-station.tar.gz
             

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,9 @@ jobs:
           echo "--------------------------------------"
           
           # Build PF_Ring libraries
-          cd PF_RING/userland/lib && ./configure && make
-          cd PF_RING/userland/libpcap && ./configure && make
+          cd $GOPATH/src/github.com/refraction-networking/conjure/PF_RING/userland/lib && ./configure && make
+          cd $GOPATH/src/github.com/refraction-networking/conjure/PF_RING/userland/libpcap && ./configure && make
+          cd $GOPATH/src/github.com/refraction-networking/conjure
           echo "PF_Ring libraries successfully built"
           echo "--------------------------------------"
 
@@ -64,8 +65,10 @@ jobs:
           go version
           which go
           # temp fix before transition to redis v8
-          # go get -u github.com/go-redis/redis || true && cd $GOPATH/src/github.com/go-redis/redis && git checkout tags/v7.4.0 -b v7-master
+          go get -u github.com/go-redis/redis || true && cd $GOPATH/src/github.com/go-redis/redis && git checkout tags/v7.4.0 -b v7-master && cd -
+          pwd
           go get -u github.com/BurntSushi/toml || true
+          go get -d -u -t github.com/refraction-networking/gotapdance/... || true
           go get -u github.com/refraction-networking/conjure/application/... || true 
           go get -u github.com/refraction-networking/conjure/registration-api/... || true 
           echo "Golang and go dependencies successfully installed"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           echo "--------------------------------------"
 
           # Install Golang
-          sudo rm -rf /usr/local/go
+          sudo rm -rf /usr/local/go /usr/bin/go
           wget -q https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
           sudo tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
           export PATH=$PATH:/usr/local/go/bin
@@ -72,6 +72,8 @@ jobs:
           echo "--------------------------------------"
 
           # Build it
+          pwd
+          cd $GOPATH/src/github.com/refraction-networking/conjure
           make
           echo "Station successfully built"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
         with:
-          path: '$GOPATH/src/github.com/refraction-networking/conjure'
+          path: '$HOME/go/src/github.com/refraction-networking/conjure'
           submodules: 'recursive'
         
       # Build the conjure station
@@ -30,6 +30,7 @@ jobs:
           # RUSTVERSION: 1.47.0
         run: |
           # Apt deps
+          pwd
           sudo apt-get update
           sudo apt-get install protobuf-compiler gcc curl git wget -y -q
           sudo apt-get install libzmq3-dev redis-server libssl-dev pkg-config libgmp3-dev -y -q

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,67 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master, staging ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-18.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          path: '$GOPATH/src/github.com/refraction-networking/conjure'
+          submodules: 'recursive'
+        
+      # Build the conjure station
+      - name: Install Conjure build dependencies 
+        env: 
+          GO_VERSION: 1.15.4
+          # RUSTVERSION: 1.47.0
+        run: |
+          # Apt deps
+          sudo apt-get install protobuf-compiler gcc curl git wget -y -q
+          sudo apt-get update && apt-get install libzmq3-dev redis-server libssl-dev pkg-config libgmp3-dev -y -q
+          
+          # Build PF_Ring libraries
+          cd PF_RING/userland/lib && ./configure && make
+          cd PF_RING/userland/libpcap && ./configure && make
+          
+          # Install rust
+          curl https://sh.rustup.rs -sSf -o install_rust.sh; sh install_rust.sh -y;          
+          cargo install protobuf-codegen
+          
+          # Install Golang
+          wget https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
+          tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
+          export PATH=$PATH:/usr/local/go/bin
+          export GOROOT="/usr/local/go"
+          mkdir -p $HOME/go
+          export GOPATH=$HOME/go
+          go version
+          # temp fix before transition to redis v8
+          go get -u github.com/go-redis/redis || true && cd /root/go/src/github.com/go-redis/redis && git checkout tags/v7.4.0 -b v7-master
+          go get -u github.com/BurntSushi/toml || true
+          go get -u github.com/refraction-networking/conjure/... || true 
+          
+          # Build it
+          make
+      
+      - name: Save Build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            dark-decoy
+            application/application
+            registration-api/registration-api
+            

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
         with:
-          path: go/src/github.com/refraction-networking/
+          path: go/src/github.com/refraction-networking/conjure
           submodules: recursive
         
       # Build the conjure station
@@ -30,9 +30,10 @@ jobs:
           # RUSTVERSION: 1.47.0
         run: |
           sudo apt install tree
-          tree
+          tree -I PF_RING
           export GOPATH=`pwd`
           echo $GOPATH
+          cd go/src/github.com/refraction-networking/conjure
           
           # Apt deps
           sudo apt-get update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,8 @@ jobs:
           GO_VERSION: 1.15.4
           # RUSTVERSION: 1.47.0
         run: |
-          sudo apt install tree
-          tree -I PF_RING
-          export GOPATH=`pwd`
-          echo $GOPATH
+          export GOPATH=`pwd`/go
+          echo "GOPATH=$GOPATH"
           cd go/src/github.com/refraction-networking/conjure
           
           # Apt deps
@@ -66,7 +64,7 @@ jobs:
           export GOROOT="/usr/local/go"
           go version
           # temp fix before transition to redis v8
-          go get -u github.com/go-redis/redis || true && cd /root/go/src/github.com/go-redis/redis && git checkout tags/v7.4.0 -b v7-master
+          go get -u github.com/go-redis/redis || true && cd $GOPATH/src/github.com/go-redis/redis && git checkout tags/v7.4.0 -b v7-master
           go get -u github.com/BurntSushi/toml || true
           go get -u github.com/refraction-networking/conjure/application/... || true 
           go get -u github.com/refraction-networking/conjure/registration-api/... || true 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
         with:
-          path: $HOME/go/src/github.com/refraction-networking/
+          path: go/src/github.com/refraction-networking/
           submodules: recursive
         
       # Build the conjure station

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
         with:
-          path: go/src/github.com/refraction-networking/
           submodules: recursive
         
       # Build the conjure station
@@ -29,6 +28,10 @@ jobs:
           GO_VERSION: 1.15.4
           # RUSTVERSION: 1.47.0
         run: |
+          export GOPATH=`pwd`
+          echo $GOPATH
+          mkdir -p go/src/github.com/refraction-networking/
+          cp -r . go/src/github.com/refraction-networking/
           cd go/src/github.com/refraction-networking/conjure
           
           # Apt deps
@@ -60,8 +63,6 @@ jobs:
           sudo tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
           export PATH=$PATH:/usr/local/go/bin
           export GOROOT="/usr/local/go"
-          mkdir -p $HOME/go
-          export GOPATH=$HOME/go
           go version
           # temp fix before transition to redis v8
           go get -u github.com/go-redis/redis || true && cd /root/go/src/github.com/go-redis/redis && git checkout tags/v7.4.0 -b v7-master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,9 @@ jobs:
           # RUSTVERSION: 1.47.0
         run: |
           # Apt deps
+          sudo apt-get update
           sudo apt-get install protobuf-compiler gcc curl git wget -y -q
-          sudo apt-get update && apt-get install libzmq3-dev redis-server libssl-dev pkg-config libgmp3-dev -y -q
+          sudo apt-get install libzmq3-dev redis-server libssl-dev pkg-config libgmp3-dev -y -q
           
           # Build PF_Ring libraries
           cd PF_RING/userland/lib && ./configure && make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,11 @@ jobs:
           # Install rust
           curl https://sh.rustup.rs -sSf -o install_rust.sh; sh install_rust.sh -y;          
           cargo install protobuf-codegen
+          export PATH=$PATH:$HOME/.cargo/bin
           
           # Install Golang
-          wget https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
-          tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
+          wget -q https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
+          sudo tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
           export PATH=$PATH:/usr/local/go/bin
           export GOROOT="/usr/local/go"
           mkdir -p $HOME/go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,24 +30,22 @@ jobs:
           # RUSTVERSION: 1.47.0
         run: |
           # Apt deps
-          pwd
           sudo apt-get update
           sudo apt-get install protobuf-compiler gcc curl git wget -y -q
           sudo apt-get install libzmq3-dev redis-server libssl-dev pkg-config libgmp3-dev -y -q
-          echo "Apt dependencies installed"
+          echo "Apt dependencies installed\n--------------------------------------"
           
           # Build PF_Ring libraries
           cd PF_RING/userland/lib && ./configure && make
           cd PF_RING/userland/libpcap && ./configure && make
-          pwd
-          echo "PF_Ring libraries successfully built"
+          echo "PF_Ring libraries successfully built\n--------------------------------------"
           
           # Install rust
           curl https://sh.rustup.rs -sSf -o install_rust.sh; sh install_rust.sh -y;          
           cargo install protobuf-codegen
           export PATH=$PATH:$HOME/.cargo/bin
           source $HOME/.cargo/env
-          echo "Rust successfully installed"
+          echo "Rust successfully installed\n--------------------------------------"
           
           # Install Golang
           wget -q https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
@@ -59,9 +57,13 @@ jobs:
           go version
           # temp fix before transition to redis v8
           go get -u github.com/go-redis/redis || true && cd /root/go/src/github.com/go-redis/redis && git checkout tags/v7.4.0 -b v7-master
+          echo "test location 1"
           go get -u github.com/BurntSushi/toml || true
-          go get -u github.com/refraction-networking/conjure/... || true 
-          echo "Golang and go dependencies successfully installed"
+          echo "test location 2"
+          go get -u github.com/refraction-networking/conjure/application/... || true 
+          echo "test location 3"
+          go get -u github.com/refraction-networking/conjure/registration-api/... || true 
+          echo "Golang and go dependencies successfully installed\n--------------------------------------"
     
           # Build it
           make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
         with:
+          path: go/src/github.com/refraction-networking/
           submodules: recursive
         
       # Build the conjure station
@@ -28,11 +29,10 @@ jobs:
           GO_VERSION: 1.15.4
           # RUSTVERSION: 1.47.0
         run: |
+          sudo apt install tree
+          tree
           export GOPATH=`pwd`
           echo $GOPATH
-          mkdir -p go/src/github.com/refraction-networking/
-          cp -r . go/src/github.com/refraction-networking/
-          cd go/src/github.com/refraction-networking/conjure
           
           # Apt deps
           sudo apt-get update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
           echo "Apt dependencies installed\n--------------------------------------"
           
           # Build PF_Ring libraries
+          ls
+          ls PF_RING
           cd PF_RING/userland/lib && ./configure && make
           cd PF_RING/userland/libpcap && ./configure && make
           echo "PF_Ring libraries successfully built\n--------------------------------------"
@@ -48,6 +50,7 @@ jobs:
           echo "Rust successfully installed\n--------------------------------------"
           
           # Install Golang
+          sudo rm -rf /usr/local/go
           wget -q https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
           sudo tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
           export PATH=$PATH:/usr/local/go/bin
@@ -57,11 +60,8 @@ jobs:
           go version
           # temp fix before transition to redis v8
           go get -u github.com/go-redis/redis || true && cd /root/go/src/github.com/go-redis/redis && git checkout tags/v7.4.0 -b v7-master
-          echo "test location 1"
           go get -u github.com/BurntSushi/toml || true
-          echo "test location 2"
           go get -u github.com/refraction-networking/conjure/application/... || true 
-          echo "test location 3"
           go get -u github.com/refraction-networking/conjure/registration-api/... || true 
           echo "Golang and go dependencies successfully installed\n--------------------------------------"
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,15 +76,15 @@ jobs:
           cd $GOPATH/src/github.com/refraction-networking/conjure
           make
           echo "Station successfully built"
-          cp dark-decoy application/application registration-api/registration-api $GITHUB_WORKSPACE
+          mkdir -p  $GITHUB_WORKSPACE/bin
+          cp dark-decoy application/application registration-api/registration-api $GITHUB_WORKSPACE/bin
+          cd $GITHUB_WORKSPACE && tar -czf conjure-station_${{ github.ref }}.tar.gz bin
           
-
       
       - name: Save Build artifacts
         uses: actions/upload-artifact@v2
         with:
+          name: conjure-${{ github.ref }}
           path: |
-            dark-decoy
-            application
-            registration-api
+            conjure-station_${{ github.ref }}.tar.gz
             


### PR DESCRIPTION
## Problem
Building on each station server individually duplicates a lot of work that can be streamlined

## Solution

Add CI pipeline to build the station here and upload artifacts to be used once pulled. This simplifies the process of deploying stations each time we change the station code and patch issues.  With this model stations need significantly fewer elements installed and can more easily manage their configurations.

#### Uses: 
ubuntu-18.04
go-1.15.4
rust-latest
pf_ring 7.2.0-stable
