### PR TITLE
Update Flow log format

### DIFF
--- a/src/process_packet.rs
+++ b/src/process_packet.rs
@@ -342,8 +342,7 @@ impl PerCoreGlobal
         match str::from_utf8(tcp_pkt.payload()) {
             Ok(payload) => {
                 if payload == SPECIAL_PACKET_PAYLOAD {
-                    debug!("Validated traffic from {}:{} to {}:{}", 
-                        flow.src_ip, flow.src_port, flow.dst_ip, flow.dst_port)
+                    debug!("Validated traffic from {}", flow)
                 }
             },
             Err(_) => {},
@@ -353,8 +352,7 @@ impl PerCoreGlobal
     fn check_udp_test_str(&mut self, flow: &Flow, udp_pkt: &UdpPacket) {
         if udp_pkt.payload().windows(SPECIAL_UDP_PAYLOAD.len())
             .any(|sub| sub == SPECIAL_UDP_PAYLOAD) {
-                debug!("Validated UDP traffic from {}:{} to {}:{}",
-                    flow.src_ip, flow.src_port, flow.dst_ip, flow.dst_port)
+                debug!("Validated UDP traffic from {}", flow)
             }
     }
 } // impl PerCoreGlobal


### PR DESCRIPTION
## Issue

IPv6 addresses are printed incorrectly by the station logging system. This breaks parsing and interpretation later down the road. 

logging involving  a flow with address 2601::1 and port 443 looks like  

```
# Current
2601::1:443 -> ...

# Correct
[2601::1]:443 -> ...
```

## Solution

To correct this I have updated the `impl fmt::Display` for the struct to use the rust `SocketAddr` system which does automatic formatting generic across IPv4 and IPv6.  I added a test to confim that the formatting was what we expected it to be.