### PR TITLE
Add Config options for subnet filtering

### DIFF
--- a/application/config.toml
+++ b/application/config.toml
@@ -29,10 +29,13 @@ heartbeat_timeout = 1000
 # connections from the station to connect to sation infrastructure that would 
 # be othewise firewalled.
 covert_blocklist = [
-    "127.0.0.1/32",
-    "10.0.0.0/8",
-    "fe80::0/16",
-    "::1/128"
+    "127.0.0.1/32",     # localhost ipv4
+    "10.0.0.0/8",       # reserved ipv4 
+    "172.16.0.0/12",    # reserved ipv4
+    "192.168.0.0/16",   # reserved ipv4
+    "fc00::/7 ",        # private network ipv6
+    "fe80::0/16",       # link local ipv6
+    "::1/128"           # localhost ipv6
 ]
 
 

--- a/application/config.toml
+++ b/application/config.toml
@@ -24,6 +24,18 @@ heartbeat_interval = 30000
 heartbeat_timeout = 1000
 
 
+# If a registration is received with an address in one of these subnets it will
+# be ignored and dropped. This is to prevent clients leveraging the outgoing
+# connections from the station to connect to sation infrastructure that would 
+# be othewise firewalled.
+covert_blocklist = [
+    "127.0.0.1/32",
+    "10.0.0.0/8",
+    "fe80::0/16",
+    "::1/128"
+]
+
+
 ### ZMQ sockets to connect to and subscribe
 
 ## Registration API

--- a/application/lib/config.go
+++ b/application/lib/config.go
@@ -44,6 +44,9 @@ func ParseConfig() (*Config, error) {
 }
 
 func (c *Config) IsBlocklisted(addr net.IP) bool {
+	if addr == nil {
+		return true
+	}
 	for _, subnet := range c.covertBlocklist {
 		if subnet.Contains(addr) {
 			return true

--- a/application/lib/config.go
+++ b/application/lib/config.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/BurntSushi/toml"
@@ -16,6 +17,10 @@ type Config struct {
 
 	// REST endpoint to share decoy registrations.
 	PreshareEndpoint string `toml:"preshare_endpoint"`
+
+	// List of subnets with disallowed covert addresses.
+	CovertBlocklist []string `toml:"covert_blocklist"`
+	covertBlocklist []*net.IPNet
 }
 
 func ParseConfig() (*Config, error) {
@@ -25,5 +30,24 @@ func ParseConfig() (*Config, error) {
 		return nil, fmt.Errorf("failed to load config: %v", err)
 	}
 
+	c.covertBlocklist = []*net.IPNet{}
+	for _, subnet := range c.CovertBlocklist {
+		_, ipNet, err := net.ParseCIDR(subnet)
+		if err != nil {
+			continue
+		}
+
+		c.covertBlocklist = append(c.covertBlocklist, ipNet)
+	}
+
 	return &c, nil
+}
+
+func (c *Config) IsBlocklisted(addr net.IP) bool {
+	for _, subnet := range c.covertBlocklist {
+		if subnet.Contains(addr) {
+			return true
+		}
+	}
+	return false
 }

--- a/application/lib/config_test.go
+++ b/application/lib/config_test.go
@@ -17,6 +17,8 @@ func TestConjureLibParseConfig(t *testing.T) {
 		t.Fatalf("No sockets provided to test parse")
 	}
 
-	// t.Logf("%+v", conf)
-	return
+	if len(conf.covertBlocklist) == 0 {
+		t.Fatalf("failed to parse blocklist")
+	}
+
 }

--- a/application/lib/config_test.go
+++ b/application/lib/config_test.go
@@ -29,4 +29,8 @@ func TestConjureLibParseConfig(t *testing.T) {
 	if conf.IsBlocklisted(net.ParseIP("1.2.3.4")) {
 		t.Fatalf("Blocklist error - 1.2.3.4 should not be blocked")
 	}
+
+	if conf.IsBlocklisted(nil) {
+		t.Fatalf("Not sure what will happen.")
+	}
 }

--- a/application/lib/config_test.go
+++ b/application/lib/config_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"net"
 	"os"
 	"testing"
 )
@@ -21,4 +22,11 @@ func TestConjureLibParseConfig(t *testing.T) {
 		t.Fatalf("failed to parse blocklist")
 	}
 
+	if !conf.IsBlocklisted(net.ParseIP("127.0.0.1")) {
+		t.Fatalf("Blocklist error - 127.0.0.1 should be blocked")
+	}
+
+	if conf.IsBlocklisted(net.ParseIP("1.2.3.4")) {
+		t.Fatalf("Blocklist error - 1.2.3.4 should not be blocked")
+	}
 }

--- a/application/main.go
+++ b/application/main.go
@@ -183,14 +183,16 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 		go func() {
 			// Handle multiple as receive_zmq_messages returns separate registrations for v4 and v6
 			for _, reg := range newRegs {
-				// If registration is trying to connect to a dark decoy that is blocklisted continue
-				if conf.IsBlocklisted(reg.DarkDecoy) {
-					continue
-				}
-
 				if reg == nil {
 					continue
 				}
+
+				// If registration is trying to connect to a dark decoy that is blocklisted continue
+				covert := net.ParseIP(reg.Covert)
+				if covert == nil || conf.IsBlocklisted(covert) {
+					continue
+				}
+
 				if !reg.PreScanned() {
 					// New registration received over channel that requires liveness scan for the phantom
 					liveness, response := reg.PhantomIsLive()

--- a/application/main.go
+++ b/application/main.go
@@ -183,7 +183,12 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 		go func() {
 			// Handle multiple as receive_zmq_messages returns separate registrations for v4 and v6
 			for _, reg := range newRegs {
-				if reg == nil || reg.RegistrationSource == nil {
+				// If registration is trying to connect to a dark decoy that is blocklisted continue
+				if conf.IsBlocklisted(reg.DarkDecoy) {
+					continue
+				}
+
+				if reg == nil {
 					continue
 				}
 				if !reg.PreScanned() {

--- a/application/main.go
+++ b/application/main.go
@@ -188,8 +188,10 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 				}
 
 				// If registration is trying to connect to a dark decoy that is blocklisted continue
-				covert := net.ParseIP(reg.Covert)
-				if covert == nil || conf.IsBlocklisted(covert) {
+				covertStr, _, err := net.SplitHostPort(reg.Covert)
+				covert := net.ParseIP(covertStr)
+				if covert == nil || err != nil || conf.IsBlocklisted(covert) {
+					logger.Printf("Dropping reg, malformed or blocklisted covert: %v, %s, %v", reg.IDString(), reg.Covert, err)
 					continue
 				}
 

--- a/application/main.go
+++ b/application/main.go
@@ -257,6 +257,15 @@ func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager) ([
 	}
 
 	conjureKeys, err := cj.GenSharedKeys(parsed.SharedSecret)
+	if parsed.GetRegistrationAddress() == nil {
+		parsed.RegistrationAddress = make([]byte, 16, 16)
+	}
+	if parsed.GetDecoyAddress() == nil {
+		parsed.DecoyAddress = make([]byte, 16, 16)
+	}
+
+	sourceAddr := net.IP(parsed.RegistrationAddress)
+	decoyAddr := net.IP(parsed.DecoyAddress)
 
 	// Register one or both of v4 and v6 based on support specified by the client
 	var newRegs []*cj.DecoyRegistration
@@ -269,7 +278,7 @@ func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager) ([
 		}
 
 		// log phantom IP, shared secret, ipv6 support
-		logger.Printf("New registration: %v\n", reg.String())
+		logger.Printf("New registration: '%v' -> '%v' %v\n", sourceAddr, decoyAddr, reg.String())
 
 		newRegs = append(newRegs, reg)
 	}
@@ -282,7 +291,7 @@ func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager) ([
 		}
 
 		// log phantom IP, shared secret, ipv6 support
-		logger.Printf("New registration: %v\n", reg.String())
+		logger.Printf("New registration: '%v' -> '%v' %v\n", sourceAddr, decoyAddr, reg.String())
 		newRegs = append(newRegs, reg)
 	}
 

--- a/application/registration_with_transport_test.go
+++ b/application/registration_with_transport_test.go
@@ -38,7 +38,8 @@ func TestManagerFunctionality(t *testing.T) {
 	rm.AddTransport(pb.TransportType_Min, min.Transport{})
 	c2s.Transport = &transport
 
-	newReg, err := rm.NewRegistration(c2s, &keys, c2s.GetV6Support())
+	source := pb.RegistrationSource_Detector
+	newReg, err := rm.NewRegistration(c2s, &keys, c2s.GetV6Support(), &source)
 	if err != nil {
 		t.Fatalf("Registration failed: %v", err)
 	}

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -48,7 +48,7 @@ extern {
                     sys_secs: *mut i64, sys_micros: *mut i64);
 
     fn open_reporter(fname: *const u8); // const char *
-    // fn write_reporter(msg: *const u8, len: size_t);
+    fn write_reporter(msg: *const u8, len: size_t);
 
     // Send a TCP RST to daddr:dport, spoofed from saddr:sport. seq must be the
     // last ACK val observed from the targeted host, so it won't ignore the ACK.

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -48,7 +48,7 @@ extern {
                     sys_secs: *mut i64, sys_micros: *mut i64);
 
     fn open_reporter(fname: *const u8); // const char *
-    fn write_reporter(msg: *const u8, len: size_t);
+    // fn write_reporter(msg: *const u8, len: size_t);
 
     // Send a TCP RST to daddr:dport, spoofed from saddr:sport. seq must be the
     // last ACK val observed from the targeted host, so it won't ignore the ACK.
@@ -214,11 +214,11 @@ pub fn c_open_reporter(fname: String)
 */
 
 #[cfg(test)]
-pub fn c_write_reporter(msg: String)
+pub fn c_write_reporter(_msg: String)
 {panic!("YOU ARE TESTING AND THIS FUNCTION IS NOT MOCKED YET!");}
 #[cfg(test)]
-pub fn c_tcp_send_rst_pkt(saddr: u32, daddr: u32,
-                          sport: u16, dport: u16, seq: u32)
+pub fn c_tcp_send_rst_pkt(_saddr: u32, _daddr: u32,
+                          _sport: u16, _dport: u16, seq: u32)
 {panic!("c_tcp_send_rst_pkt({}) called", seq);}
 /*
 pub fn c_get_global_cli_conf() -> *const ClientConf

--- a/src/process_packet.rs
+++ b/src/process_packet.rs
@@ -20,7 +20,7 @@ use flow_tracker::{Flow, FlowNoSrcPort};
 use PerCoreGlobal;
 use util::IpPacket;
 use elligator;
-use protobuf::{Message, SingularPtrField};
+use protobuf::{Message};
 use signalling::{C2SWrapper, RegistrationSource};
 
 
@@ -308,10 +308,14 @@ impl PerCoreGlobal
                 let mut zmq_msg = C2SWrapper::new();
 
                 let shared_secret = res.0.to_vec();
+                let (src,decoy) = flow.export_addrs();
                 let vsp = res.2;
+
                 zmq_msg.set_shared_secret(shared_secret);
                 zmq_msg.set_registration_payload(vsp);
                 zmq_msg.set_registration_source(RegistrationSource::Detector);
+                zmq_msg.set_decoy_address(decoy);
+                zmq_msg.set_registration_address(src);
 
                 let repr_str = hex::encode(res.0);
                 debug!("New registration {}, {}", flow, repr_str);


### PR DESCRIPTION
## Problem

Registrations are currently allowed which redirect traffic to any address as a covert target. This allows users to connect to dangerous addresses like `127.0.0.1`, `10.0.0.0/8`,  etc.

## Solution

This PR adds a list of disallowed subnets to the station config which are checked before marking the registration valid. By default the private subnets are included here. Ideally station operators will add the addresses of their stations when configuring during setup to prevent unauthorized connections to station operations. 

## Secondary 

* Fix a few compile warnings in the rust detector portion of the station. 

* Add the source and destination addresses of the traffic to the zmq payload that is sent from the detector to the station so that it can be logged with the application information.