### PR TITLE
Detector Address filtering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ name = "rust_dark_decoy"
 crate-type = ["rlib", "staticlib"]
 
 [dependencies]
+toml = "0.5.8"
+serde = "^1.0.0"
+serde_derive = "^1.0.0"
 lazycell = "^0.5"
 libc = "~0.2"
 aes-gcm = "0.8.0"

--- a/application/config.toml
+++ b/application/config.toml
@@ -39,6 +39,15 @@ covert_blocklist = [
 ]
 
 
+# List of addresses to filter out traffic from the detector. The primary functionality
+# of this is to prevent liveness testing from other stations in a conjure cluster from
+# clogging up the logs with connection notifications. To accomplish this goal add all station
+# ip addresses to this list when configuring station detectors.
+detector_filter_list = [
+    "127.0.0.1",
+    "::1",
+]
+
 ### ZMQ sockets to connect to and subscribe
 
 ## Registration API


### PR DESCRIPTION
## Problem

When stations perform liveness checks the connections from the stations to the phantom address picked up by the detector and registered as a potential connection. This creates a number of log lines and forces the station to attempt to handle the connections. To prevent this there is a list of source addresses to filter traffic out of the connection checks. This is currently hard coded and not easily configurable

## Solution

Move the filter addresses to the station config and have each core parse the filter addresses during initialization. They probably don't need to be per core because they aren't unique and they aren't mutable, but that is how we currently track things. 

## Note

In this patch each core parses the station toml config once at initialization and only takes out the pices it needs (i.e. the filter address list).  However, the station config could be fully parsed if we wanted to access other configurable elements here.   