### PR TITLE
Early registration lookup in station tracking

### DIFF
--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -423,6 +423,11 @@ func (r *RegisteredDecoys) track(d *DecoyRegistration) error {
 	d.regCount = 1
 	d.Valid = false
 
+	_, exists := r.decoys[phantomAddr]
+	if !exists {
+		r.decoys[phantomAddr] = map[string]*DecoyRegistration{}
+	}
+
 	r.decoys[phantomAddr][identifier] = d
 
 	r.decoysTimeouts = append(r.decoysTimeouts,
@@ -438,9 +443,6 @@ func (r *RegisteredDecoys) track(d *DecoyRegistration) error {
 
 func (r *RegisteredDecoys) register(darkDecoyAddr string, d *DecoyRegistration) error {
 
-	r.m.Lock()
-	defer r.m.Unlock()
-
 	reg := r.registrationExists(d)
 	if reg == nil {
 		// Track unknown registration
@@ -455,6 +457,9 @@ func (r *RegisteredDecoys) register(darkDecoyAddr string, d *DecoyRegistration) 
 			return fmt.Errorf("failed to track and register %s with unknown error", d.IDString())
 		}
 	}
+
+	r.m.Lock()
+	defer r.m.Unlock()
 
 	if reg.Valid {
 		// Registration has already been shared with the detector

--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -18,9 +18,16 @@ import (
 	pb "github.com/refraction-networking/gotapdance/protobuf"
 )
 
+// DETECTOR_REG_CHANNEL is a constant that defines the name of the redis map that we
+// send validated registrations over in order to notify all detector cores.
 const DETECTOR_REG_CHANNEL string = "dark_decoy_map"
+
+// AES_GCM_TAG_SIZE the size of the aesgcm tag used when generating the client to
+// station message.
 const AES_GCM_TAG_SIZE = 16
 
+// Transport defines the interface for the manager to interface with variable
+// transports that wrap the traffic sent by clients.
 type Transport interface {
 	// The human-friendly name of the transport.
 	Name() string
@@ -73,6 +80,7 @@ type ConnectingTransport interface {
 	Connect(context.Context, *DecoyRegistration) (net.Conn, error)
 }
 
+// RegistrationManager manages registration tracking for the station.
 type RegistrationManager struct {
 	registeredDecoys *RegisteredDecoys
 	Logger           *log.Logger
@@ -94,6 +102,8 @@ func NewRegistrationManager() *RegistrationManager {
 	}
 }
 
+// AddTransport initializes a transport so that it can be tracked by the manager when
+// clients register.
 func (regManager *RegistrationManager) AddTransport(index pb.TransportType, t Transport) {
 	regManager.registeredDecoys.m.Lock()
 	defer regManager.registeredDecoys.m.Unlock()
@@ -101,7 +111,7 @@ func (regManager *RegistrationManager) AddTransport(index pb.TransportType, t Tr
 	regManager.registeredDecoys.transports[index] = t
 }
 
-// Returns a map of the wrapping transport types to their transports. This return value
+// GetWrappingTransports Returns a map of the wrapping transport types to their transports. This return value
 // can be mutated freely.
 func (regManager *RegistrationManager) GetWrappingTransports() map[pb.TransportType]WrappingTransport {
 	m := make(map[pb.TransportType]WrappingTransport)
@@ -118,8 +128,8 @@ func (regManager *RegistrationManager) GetWrappingTransports() map[pb.TransportT
 	return m
 }
 
-// NewRegistration creates a new registration from details provided. Does NOT add the registration
-// to tracking map.
+// NewRegistration creates a new registration from details provided. Adds the registration
+// to tracking map, But marks it as not valid.
 func (regManager *RegistrationManager) NewRegistration(c2s *pb.ClientToStation, conjureKeys *ConjureSharedKeys, includeV6 bool, registrationSource *pb.RegistrationSource) (*DecoyRegistration, error) {
 
 	phantomAddr, err := regManager.PhantomSelector.Select(
@@ -145,6 +155,16 @@ func (regManager *RegistrationManager) NewRegistration(c2s *pb.ClientToStation, 
 	return &reg, nil
 }
 
+// TrackRegistration adds the registration to the map WITHOUT marking it valid.
+func (regManager *RegistrationManager) TrackRegistration(d *DecoyRegistration) error {
+	err := regManager.registeredDecoys.track(d)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// AddRegistration officially adds the registration to usage by marking it as valid.
 func (regManager *RegistrationManager) AddRegistration(d *DecoyRegistration) {
 
 	darkDecoyAddr := d.DarkDecoy.String()
@@ -154,23 +174,30 @@ func (regManager *RegistrationManager) AddRegistration(d *DecoyRegistration) {
 	}
 }
 
-// RegistrationExists checks if the registration is already tracked by the manager
+// RegistrationExists checks if the registration is already tracked by the manager, this is
+// independent of the validity tag, this just checks to see if the registration exists.
 func (regManager *RegistrationManager) RegistrationExists(reg *DecoyRegistration) bool {
-	return regManager.registeredDecoys.registrationExists(reg)
+	trackedReg := regManager.registeredDecoys.registrationExists(reg)
+	return trackedReg != nil
 }
 
-func (regManager *RegistrationManager) GetRegistrations(darkDecoyAddr net.IP) map[string]*DecoyRegistration {
-	return regManager.registeredDecoys.GetRegistrations(darkDecoyAddr)
+// GetRegistrations returns registrations associated with a specific phantom address.
+func (regManager *RegistrationManager) GetRegistrations(phantomAddr net.IP) map[string]*DecoyRegistration {
+	return regManager.registeredDecoys.getRegistrations(phantomAddr)
 }
 
-func (regManager *RegistrationManager) CountRegistrations(darkDecoyAddr net.IP) int {
-	return regManager.registeredDecoys.countRegistrations(darkDecoyAddr)
+// CountRegistrations counts the number of registrations tracked that are using a
+// specific phantom address.
+func (regManager *RegistrationManager) CountRegistrations(phantomAddr net.IP) int {
+	return regManager.registeredDecoys.countRegistrations(phantomAddr)
 }
 
+// RemoveOldRegistrations garbage collects old registrations
 func (regManager *RegistrationManager) RemoveOldRegistrations() {
 	regManager.registeredDecoys.removeOldRegistrations(regManager.Logger)
 }
 
+// DecoyRegistration is a struct for tracking individual sessions that are expecting or tracking connections.
 type DecoyRegistration struct {
 	DarkDecoy          net.IP
 	Keys               *ConjureSharedKeys
@@ -181,6 +208,10 @@ type DecoyRegistration struct {
 	RegistrationSource *pb.RegistrationSource
 	DecoyListVersion   uint32
 	regCount           int32
+
+	// validity marks whether the registration has been validated through liveness and other checks.
+	// This also denotes whether the registration has been shared with the detector.
+	Valid bool
 }
 
 // String -- Print a digest of the important identifying information for this registration.
@@ -371,47 +402,72 @@ func NewRegisteredDecoys() *RegisteredDecoys {
 	}
 }
 
-func (r *RegisteredDecoys) register(darkDecoyAddr string, d *DecoyRegistration) error {
+func (r *RegisteredDecoys) track(d *DecoyRegistration) error {
 
-	r.m.Lock()
-	defer r.m.Unlock()
+	// Is the registration is already tracked.
+	if reg := r.registrationExists(d); reg != nil {
+		// update tracked registration with new information if any
+		reg.regCount++
+		return nil
+	}
 
 	t, ok := r.transports[d.Transport]
 	if !ok {
 		return fmt.Errorf("unknown transport %d", d.Transport)
 	}
 
+	phantomAddr := d.DarkDecoy.String()
 	identifier := t.GetIdentifier(d)
 
-	_, exists := r.decoys[darkDecoyAddr]
-	if exists == false {
-		r.decoys[darkDecoyAddr] = map[string]*DecoyRegistration{}
-	}
+	// Newly tracked registrations are not valid and have only been seen once.
+	d.regCount = 1
+	d.Valid = false
 
-	reg, exists := r.decoys[darkDecoyAddr][identifier]
-	if exists == false {
-		// New Registration not known to the Manager
-		r.decoys[darkDecoyAddr][identifier] = d
+	r.decoys[phantomAddr][identifier] = d
 
-		r.decoysTimeouts = append(r.decoysTimeouts,
-			DecoyTimeout{
-				decoy:            darkDecoyAddr,
-				identifier:       identifier,
-				registrationTime: time.Now(),
-				regID:            d.IDString(),
-			})
-
-		//[TODO]{priority:5} track what registration decoys are seen for a given session
-		d.regCount = 1
-		registerForDetector(d)
-	} else {
-		reg.regCount++
-	}
+	r.decoysTimeouts = append(r.decoysTimeouts,
+		DecoyTimeout{
+			decoy:            phantomAddr,
+			identifier:       identifier,
+			registrationTime: time.Now(),
+			regID:            d.IDString(),
+		})
 
 	return nil
 }
 
-func (r *RegisteredDecoys) GetRegistrations(darkDecoyAddr net.IP) map[string]*DecoyRegistration {
+func (r *RegisteredDecoys) register(darkDecoyAddr string, d *DecoyRegistration) error {
+
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	reg := r.registrationExists(d)
+	if reg == nil {
+		// Track unknown registration
+		err := r.track(d)
+		if err != nil {
+			return err
+		}
+
+		// Get a reference to the registration so we can update the valid tag.
+		reg = r.registrationExists(d)
+		if reg == nil {
+			return fmt.Errorf("failed to track and register %s with unknown error", d.IDString())
+		}
+	}
+
+	if reg.Valid {
+		// Registration has already been shared with the detector
+		return nil
+	}
+
+	reg.Valid = true
+	registerForDetector(reg)
+
+	return nil
+}
+
+func (r *RegisteredDecoys) getRegistrations(darkDecoyAddr net.IP) map[string]*DecoyRegistration {
 	darkDecoyAddrStatic := darkDecoyAddr.String()
 	r.m.RLock()
 	defer r.m.RUnlock()
@@ -420,7 +476,11 @@ func (r *RegisteredDecoys) GetRegistrations(darkDecoyAddr net.IP) map[string]*De
 
 	regs := make(map[string]*DecoyRegistration)
 	for k, v := range original {
-		regs[k] = v
+		if v.Valid {
+			// only return valid registration so we don't allow connections to a
+			// registration that has not been validated yet.
+			regs[k] = v
+		}
 	}
 
 	return regs
@@ -438,14 +498,13 @@ func (r *RegisteredDecoys) countRegistrations(darkDecoyAddr net.IP) int {
 	return len(regs)
 }
 
-func (r *RegisteredDecoys) registrationExists(d *DecoyRegistration) bool {
+func (r *RegisteredDecoys) registrationExists(d *DecoyRegistration) *DecoyRegistration {
 	r.m.Lock()
 	defer r.m.Unlock()
 
 	t, ok := r.transports[d.Transport]
 	if !ok {
-		fmt.Printf("Failing here\n")
-		return false
+		return nil
 	}
 
 	identifier := t.GetIdentifier(d)
@@ -454,11 +513,15 @@ func (r *RegisteredDecoys) registrationExists(d *DecoyRegistration) bool {
 
 	_, exists := r.decoys[phantomAddr]
 	if !exists {
-		return false
+		return nil
 	}
 
-	_, exists = r.decoys[phantomAddr][identifier]
-	return exists
+	reg, exists := r.decoys[phantomAddr][identifier]
+	if !exists {
+		return nil
+	}
+
+	return reg
 }
 
 type regExpireLogMsg struct {

--- a/application/main.go
+++ b/application/main.go
@@ -175,8 +175,12 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 	for {
 
 		newRegs, err := recieve_zmq_message(sub, regManager)
-		if err != nil || len(newRegs) == 0 {
+		if err != nil {
 			logger.Printf("Encountered err when creating Reg: %v\n", err)
+			continue
+		}
+		if len(newRegs) == 0 {
+			// no new registration
 			continue
 		}
 
@@ -209,7 +213,7 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 					go tryShareRegistrationOverAPI(reg, conf.PreshareEndpoint)
 				}
 
-				// track new registration
+				// validate the registration
 				regManager.AddRegistration(reg)
 				logger.Printf("Adding registration %v, from %s\n", reg.IDString(), *reg.RegistrationSource)
 			}

--- a/application/main.go
+++ b/application/main.go
@@ -289,16 +289,18 @@ func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager) ([
 		if regManager.RegistrationExists(reg) {
 			// log phantom IP, shared secret, ipv6 support
 			logger.Printf("Duplicate registration: '%v' -> '%v' %v\n", sourceAddr, decoyAddr, reg.String())
-
-			// Track the additional registration received, but do not add to list of new
-			// registrations so that we can skip processing it again.
-			regManager.AddRegistration(reg)
 		} else {
 			// log phantom IP, shared secret, ipv6 support
 			logger.Printf("New registration: '%v' -> '%v' %v\n", sourceAddr, decoyAddr, reg.String())
 
 			// add to list of new registrations to be processed.
 			newRegs = append(newRegs, reg)
+		}
+
+		// Track the received registration, if it is already tracked it will just update the record
+		regManager.TrackRegistration(reg)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -311,16 +313,18 @@ func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager) ([
 		if regManager.RegistrationExists(reg) {
 			// log phantom IP, shared secret, ipv6 support
 			logger.Printf("Duplicate registration: '%v' -> '%v' %v\n", sourceAddr, decoyAddr, reg.String())
-
-			// Track the additional registration received, but do not add to list of new
-			// registrations so that we can skip processing it again.
-			regManager.AddRegistration(reg)
 		} else {
 			// log phantom IP, shared secret, ipv6 support
 			logger.Printf("New registration: '%v' -> '%v' %v\n", sourceAddr, decoyAddr, reg.String())
 
 			// add to list of new registrations to be processed.
 			newRegs = append(newRegs, reg)
+		}
+
+		// Track the received registration, if it is already tracked it will just update the record
+		regManager.TrackRegistration(reg)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/application/main.go
+++ b/application/main.go
@@ -286,10 +286,20 @@ func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager) ([
 			return nil, err
 		}
 
-		// log phantom IP, shared secret, ipv6 support
-		logger.Printf("New registration: '%v' -> '%v' %v\n", sourceAddr, decoyAddr, reg.String())
+		if regManager.RegistrationExists(reg) {
+			// log phantom IP, shared secret, ipv6 support
+			logger.Printf("Duplicate registration: '%v' -> '%v' %v\n", sourceAddr, decoyAddr, reg.String())
 
-		newRegs = append(newRegs, reg)
+			// Track the additional registration received, but do not add to list of new
+			// registrations so that we can skip processing it again.
+			regManager.AddRegistration(reg)
+		} else {
+			// log phantom IP, shared secret, ipv6 support
+			logger.Printf("New registration: '%v' -> '%v' %v\n", sourceAddr, decoyAddr, reg.String())
+
+			// add to list of new registrations to be processed.
+			newRegs = append(newRegs, reg)
+		}
 	}
 
 	if parsed.RegistrationPayload.GetV6Support() {
@@ -298,10 +308,20 @@ func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager) ([
 			logger.Printf("Failed to create registration: %v", err)
 			return nil, err
 		}
+		if regManager.RegistrationExists(reg) {
+			// log phantom IP, shared secret, ipv6 support
+			logger.Printf("Duplicate registration: '%v' -> '%v' %v\n", sourceAddr, decoyAddr, reg.String())
 
-		// log phantom IP, shared secret, ipv6 support
-		logger.Printf("New registration: '%v' -> '%v' %v\n", sourceAddr, decoyAddr, reg.String())
-		newRegs = append(newRegs, reg)
+			// Track the additional registration received, but do not add to list of new
+			// registrations so that we can skip processing it again.
+			regManager.AddRegistration(reg)
+		} else {
+			// log phantom IP, shared secret, ipv6 support
+			logger.Printf("New registration: '%v' -> '%v' %v\n", sourceAddr, decoyAddr, reg.String())
+
+			// add to list of new registrations to be processed.
+			newRegs = append(newRegs, reg)
+		}
 	}
 
 	return newRegs, nil


### PR DESCRIPTION
## Issue

During the registration process a station may receive the same registration multiple times. Currently this results in the registration being fully processed each time it is received, including liveness testing. However it is entirely possible to do an early lookup and prevent the extra processing for registrations that are already valid  

## Solution

To fix this I have added a `RegistrationExists` function to the registration manager which allows the station to do a lookup upon receiving a registration to check if the registration is already known. If the registration is already tracked the station short circuits the processing pipeline and returns. 

## Note

Based on the way that the registratiion manager tracks registrations, v4 and v6 registrations are tracked independently so adding to the count for each is the correct behavior, even if they were received as part of the same registration connection. 