### PR TITLE
Client IP Loggging

### DIFF
--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -390,14 +390,15 @@ type RegisteredDecoys struct {
 
 	transports map[pb.TransportType]Transport
 
-	decoysTimeouts []DecoyTimeout
+	decoysTimeouts map[string]*DecoyTimeout
 	m              sync.RWMutex
 }
 
 func NewRegisteredDecoys() *RegisteredDecoys {
 	return &RegisteredDecoys{
-		decoys:     make(map[string]map[string]*DecoyRegistration),
-		transports: make(map[pb.TransportType]Transport),
+		decoys:         make(map[string]map[string]*DecoyRegistration),
+		transports:     make(map[pb.TransportType]Transport),
+		decoysTimeouts: make(map[string]*DecoyTimeout),
 	}
 }
 
@@ -405,6 +406,9 @@ func (r *RegisteredDecoys) track(d *DecoyRegistration) error {
 
 	// Is the registration is already tracked.
 	if reg := r.registrationExists(d); reg != nil {
+		r.m.Lock()
+		defer r.m.Unlock()
+
 		// update tracked registration with new information if any
 		reg.regCount++
 		return nil
@@ -429,13 +433,13 @@ func (r *RegisteredDecoys) track(d *DecoyRegistration) error {
 
 	r.decoys[phantomAddr][identifier] = d
 
-	r.decoysTimeouts = append(r.decoysTimeouts,
-		DecoyTimeout{
-			decoy:            phantomAddr,
-			identifier:       identifier,
-			registrationTime: time.Now(),
-			regID:            d.IDString(),
-		})
+	newtimeout := &DecoyTimeout{
+		decoy:            phantomAddr,
+		identifier:       identifier,
+		registrationTime: time.Now(),
+		regID:            d.IDString(),
+	}
+	r.decoysTimeouts[d.IDString()+phantomAddr] = newtimeout
 
 	return nil
 }
@@ -490,6 +494,14 @@ func (r *RegisteredDecoys) getRegistrations(darkDecoyAddr net.IP) map[string]*De
 	return regs
 }
 
+func (r *RegisteredDecoys) totalRegistrations() int {
+	total := 0
+	for _, regSet := range r.decoys {
+		total += len(regSet)
+	}
+	return total
+}
+
 func (r *RegisteredDecoys) countRegistrations(darkDecoyAddr net.IP) int {
 	ddAddrStr := darkDecoyAddr.String()
 	r.m.RLock()
@@ -503,8 +515,6 @@ func (r *RegisteredDecoys) countRegistrations(darkDecoyAddr net.IP) int {
 }
 
 func (r *RegisteredDecoys) registrationExists(d *DecoyRegistration) *DecoyRegistration {
-	r.m.Lock()
-	defer r.m.Unlock()
 
 	t, ok := r.transports[d.Transport]
 	if !ok {
@@ -535,23 +545,37 @@ type regExpireLogMsg struct {
 	RegCount   int32
 }
 
+// This whole process of tracking timeouts and registrations separately
+// makes less and less sense every time I come back to it.
 func (r *RegisteredDecoys) removeOldRegistrations(logger *log.Logger) {
-	const timeout = -time.Minute * 5
-	cutoff := time.Now().Add(timeout)
-	idx := 0
+	const regTimeout = time.Minute * 2
+	cutoff := time.Now().Add(-regTimeout)
+
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	logger.Printf("cleansing registrations")
-	for idx := 0; idx < len(r.decoysTimeouts); idx++ {
-		if cutoff.After(r.decoysTimeouts[idx].registrationTime) {
-			break
+	var expiredRegTimeoutIndices = []string{}
+
+	for idx, decoyTimeout := range r.decoysTimeouts {
+		if decoyTimeout.registrationTime.Before(cutoff) {
+			// if a registration was received before the cutoff time add it
+			// to the list of registrations to be removed.
+			expiredRegTimeoutIndices = append(expiredRegTimeoutIndices, idx)
 		}
+	}
+	logger.Printf("remove: %+v",expiredRegTimeoutIndices)
+
+	logger.Printf("cleansing registrations - registrations: %d, timeouts: %d, expired: %d",
+		r.totalRegistrations(), len(r.decoysTimeouts), len(expiredRegTimeoutIndices))
+
+	for _, idx := range expiredRegTimeoutIndices {
 		expiredReg := r.decoysTimeouts[idx]
 		expiredRegObj, ok := r.decoys[expiredReg.decoy][expiredReg.identifier]
 		if !ok {
 			continue
 		}
+
+		// remove from decoy tracking
 		delete(r.decoys[expiredReg.decoy], expiredReg.identifier)
 		stats := regExpireLogMsg{
 			DecoyAddr:  expiredReg.decoy,
@@ -560,9 +584,12 @@ func (r *RegisteredDecoys) removeOldRegistrations(logger *log.Logger) {
 			RegCount:   expiredRegObj.regCount,
 		}
 		statsStr, _ := json.Marshal(stats)
+
+		// remove from timeout tracking
+		delete(r.decoysTimeouts, idx)
+
 		logger.Printf("expired registration %s", statsStr)
 	}
-	r.decoysTimeouts = r.decoysTimeouts[idx:]
 }
 
 func registerForDetector(reg *DecoyRegistration) {

--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -234,7 +234,6 @@ func (reg *DecoyRegistration) String() string {
 	}{
 		Phantom:          reg.DarkDecoy.String(),
 		SharedSecret:     hex.EncodeToString(reg.Keys.SharedSecret),
-		Covert:           reg.Covert,
 		Mask:             reg.Mask,
 		Flags:            reg.Flags,
 		Transport:        reg.Transport,

--- a/application/main.go
+++ b/application/main.go
@@ -69,9 +69,11 @@ func handleNewConn(regManager *cj.RegistrationManager, clientConn *net.TCPConn) 
 
 	var originalDst, originalSrc string
 	if logClientIP {
-		originalDst = originalDstIP.String()
+		originalSrc = clientConn.RemoteAddr().String()
+	} else {
+		originalSrc = "_"
 	}
-	originalSrc = clientConn.RemoteAddr().String()
+	originalDst = originalDstIP.String()
 	flowDescription := fmt.Sprintf("%s -> %s ", originalSrc, originalDst)
 	logger := log.New(os.Stdout, "[CONN] "+flowDescription, log.Ldate|log.Lmicroseconds)
 

--- a/application/main.go
+++ b/application/main.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -66,8 +67,11 @@ func handleNewConn(regManager *cj.RegistrationManager, clientConn *net.TCPConn) 
 	}
 	fd.Close()
 
-	originalDst := originalDstIP.String()
-	originalSrc := clientConn.RemoteAddr().String()
+	var originalDst, originalSrc string
+	if logClientIP {
+		originalDst = originalDstIP.String()
+	}
+	originalSrc = clientConn.RemoteAddr().String()
 	flowDescription := fmt.Sprintf("%s -> %s ", originalSrc, originalDst)
 	logger := log.New(os.Stdout, "[CONN] "+flowDescription, log.Ldate|log.Lmicroseconds)
 
@@ -150,11 +154,12 @@ readLoop:
 			// We found our transport! First order of business: disable deadline
 			wrapped.SetDeadline(time.Time{})
 			logger.SetPrefix(fmt.Sprintf("[%s] %s ", t.LogPrefix(), reg.IDString()))
-			logger.Printf("registration found {reg_id: %s, phantom: %s, transport: %s, covert: %s}\n", reg.IDString(), originalDstIP, t.Name(), reg.Covert)
+			logger.Printf("registration found {reg_id: %s, phantom: %s, transport: %s}\n", reg.IDString(), originalDstIP, t.Name())
 			break readLoop
 		}
 	}
 
+	// TODO logging-client-ip
 	cj.Proxy(reg, wrapped, logger)
 }
 
@@ -215,7 +220,7 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 
 				// validate the registration
 				regManager.AddRegistration(reg)
-				logger.Printf("Adding registration %v, from %s\n", reg.IDString(), *reg.RegistrationSource)
+				logger.Printf("Adding registration %v\n", reg.IDString())
 			}
 		}()
 
@@ -277,8 +282,12 @@ func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager) ([
 		parsed.DecoyAddress = make([]byte, 16, 16)
 	}
 
-	sourceAddr := net.IP(parsed.RegistrationAddress)
-	decoyAddr := net.IP(parsed.DecoyAddress)
+	// If client IP logging is disabled DO NOT parse source IP.
+	var sourceAddr, decoyAddr net.IP
+	if logClientIP {
+		sourceAddr = net.IP(parsed.RegistrationAddress)
+	}
+	decoyAddr = net.IP(parsed.DecoyAddress)
 
 	// Register one or both of v4 and v6 based on support specified by the client
 	var newRegs []*cj.DecoyRegistration
@@ -336,10 +345,11 @@ func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager) ([
 }
 
 var logger *log.Logger
+var logClientIP = false
 
 func main() {
 	rand.Seed(time.Now().UnixNano())
-
+	var err error
 	var zmqAddress string
 	flag.StringVar(&zmqAddress, "zmq-address", "ipc://@zmq-proxy", "Address of ZMQ proxy")
 	flag.Parse()
@@ -347,6 +357,14 @@ func main() {
 	regManager := cj.NewRegistrationManager()
 	logger = regManager.Logger
 
+	// Should we log client IP addresses
+	logClientIP, err = strconv.ParseBool(os.Getenv("LOG_CLIENT_IP"))
+	if err != nil {
+		logger.Printf("failed parse client ip logging setting: %v\n", err)
+		logClientIP = false
+	}
+
+	// parse toml station configuration
 	conf, err := cj.ParseConfig()
 	if err != nil {
 		logger.Fatalf("failed to parse app config: %v", err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,16 @@ impl PerCoreGlobal
         let value: StationConfig = toml::from_str(&contents)
             .expect("Failed to parse toml station config");
 
+        // Also all threads read the same environment variable so they will all
+        // set it the same, race condition for setting client ip logging doesn't
+        // affect the outcome. LOG_CLIENT_IP set in conjure.conf
+        let client_ip_logging_str = env::var("LOG_CLIENT_IP").unwrap();
+        match client_ip_logging_str.as_ref() {
+            "true" => Flow::set_log_client(true),
+            "false" => Flow::set_log_client(false),
+            &_ => Flow::set_log_client(false), // default disable 
+        };
+
         PerCoreGlobal {
             priv_key: priv_key,
             lcore: the_lcore,

--- a/sysconfig/conjure.conf
+++ b/sysconfig/conjure.conf
@@ -31,3 +31,6 @@ CJ_QUEUE_OFFSET=0
  
 # Path to the configuration file for the registration api. Used by the conjure-zmq-proxy service
 CJ_STATION_CONFIG=/opt/conjure/application/config.toml
+
+# Allow the station to log client IPs (default disabled)
+LOG_CLIENT_IP=false


### PR DESCRIPTION
## Issue

Conjure station by default log associate client IPs with connection checkpoints. This is not always desired behavior.

## Solution

This PR adds an environment variable to the `conjure.conf` that is set during initialization in the detector, the station application, and the registration API. If set to true client IP addresses will be included in logs.  If the value is missing or set false client IP addresses will be excluded from logs. 