### PR TITLE
Prod Patches

### DIFF
--- a/application/config.toml
+++ b/application/config.toml
@@ -23,6 +23,11 @@ heartbeat_interval = 30000
 # a response before the connection is assumed to be dead.
 heartbeat_timeout = 1000
 
+# Allow the station to opt out of either version of internet protocol to limit a 
+# statio to handling one or the other. For example, v6 on small station deployment
+# with only v6 phantom subnet,  v4 only on station with no puvlic v6 address. 
+enable_v4 = true
+enable_v6 = false
 
 # If a registration is received with an address in one of these subnets it will
 # be ignored and dropped. This is to prevent clients leveraging the outgoing

--- a/application/lib/config.go
+++ b/application/lib/config.go
@@ -18,6 +18,10 @@ type Config struct {
 	// REST endpoint to share decoy registrations.
 	PreshareEndpoint string `toml:"preshare_endpoint"`
 
+	// isthe station capable of handling v4 / v6 with independent toggles. 
+	EnableIPv4 bool `toml:"enable_v4"`
+	EnableIPv6 bool  `toml:"enable_v6"`
+
 	// List of subnets with disallowed covert addresses.
 	CovertBlocklist []string `toml:"covert_blocklist"`
 	covertBlocklist []*net.IPNet

--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -202,8 +202,7 @@ func twoWayProxy(reg *DecoyRegistration, clientConn *net.TCPConn, originalDstIP 
 }
 
 func writePROXYHeader(conn net.Conn, originalIPPort string) error {
-	logger := log.New(os.Stdout, "[2WP] ", log.Ldate|log.Lmicroseconds)
-	logger.Println("Writing Proxy Header")
+
 	if len(originalIPPort) == 0 {
 		return errors.New("can't write PROXY header: empty IP")
 	}

--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -339,11 +339,12 @@ func (reg *DecoyRegistration) PhantomIsLive() (bool, error) {
 }
 
 func phantomIsLive(address string) (bool, error) {
-	width := 2
+	width := 4
 	dialError := make(chan error, width)
+	timeout := 750 * time.Millisecond
 
 	testConnect := func() {
-		conn, err := net.Dial("tcp", address)
+		conn, err := net.DialTimeout("tcp", address, timeout)
 		if err != nil {
 			dialError <- err
 			return
@@ -355,8 +356,6 @@ func phantomIsLive(address string) (bool, error) {
 	for i := 0; i < width; i++ {
 		go testConnect()
 	}
-
-	timeout := 750 * time.Millisecond
 
 	time.Sleep(timeout)
 

--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -157,7 +157,7 @@ func (regManager *RegistrationManager) NewRegistration(c2s *pb.ClientToStation, 
 
 // TrackRegistration adds the registration to the map WITHOUT marking it valid.
 func (regManager *RegistrationManager) TrackRegistration(d *DecoyRegistration) error {
-	err := regManager.registeredDecoys.track(d)
+	err := regManager.registeredDecoys.Track(d)
 	if err != nil {
 		return err
 	}
@@ -402,9 +402,16 @@ func NewRegisteredDecoys() *RegisteredDecoys {
 	}
 }
 
-func (r *RegisteredDecoys) track(d *DecoyRegistration) error {
+// For use outside of this struct (so there are no data races.)
+func (r *RegisteredDecoys) Track(d *DecoyRegistration) error {
 	r.m.Lock()
 	defer r.m.Unlock()
+
+	return r.track(d)
+}
+
+// For use inside of this struct (so no deadlocks on struct mutex)
+func (r *RegisteredDecoys) track(d *DecoyRegistration) error {
 
 	// Is the registration is already tracked.
 	if reg := r.registrationExists(d); reg != nil {

--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -177,7 +177,7 @@ func (regManager *RegistrationManager) AddRegistration(d *DecoyRegistration) {
 // RegistrationExists checks if the registration is already tracked by the manager, this is
 // independent of the validity tag, this just checks to see if the registration exists.
 func (regManager *RegistrationManager) RegistrationExists(reg *DecoyRegistration) bool {
-	trackedReg := regManager.registeredDecoys.registrationExists(reg)
+	trackedReg := regManager.registeredDecoys.RegistrationExists(reg)
 	return trackedReg != nil
 }
 
@@ -339,7 +339,7 @@ func (reg *DecoyRegistration) PhantomIsLive() (bool, error) {
 }
 
 func phantomIsLive(address string) (bool, error) {
-	width := 8
+	width := 2
 	dialError := make(chan error, width)
 
 	testConnect := func() {
@@ -403,12 +403,11 @@ func NewRegisteredDecoys() *RegisteredDecoys {
 }
 
 func (r *RegisteredDecoys) track(d *DecoyRegistration) error {
+	r.m.Lock()
+	defer r.m.Unlock()
 
 	// Is the registration is already tracked.
 	if reg := r.registrationExists(d); reg != nil {
-		r.m.Lock()
-		defer r.m.Unlock()
-
 		// update tracked registration with new information if any
 		reg.regCount++
 		return nil
@@ -446,6 +445,9 @@ func (r *RegisteredDecoys) track(d *DecoyRegistration) error {
 
 func (r *RegisteredDecoys) register(darkDecoyAddr string, d *DecoyRegistration) error {
 
+	r.m.Lock()
+	defer r.m.Unlock()
+
 	reg := r.registrationExists(d)
 	if reg == nil {
 		// Track unknown registration
@@ -460,9 +462,6 @@ func (r *RegisteredDecoys) register(darkDecoyAddr string, d *DecoyRegistration) 
 			return fmt.Errorf("failed to track and register %s with unknown error", d.IDString())
 		}
 	}
-
-	r.m.Lock()
-	defer r.m.Unlock()
 
 	if reg.Valid {
 		// Registration has already been shared with the detector
@@ -514,6 +513,16 @@ func (r *RegisteredDecoys) countRegistrations(darkDecoyAddr net.IP) int {
 	return len(regs)
 }
 
+// For use outside of this struct (so there are no data races.)
+func (r *RegisteredDecoys) RegistrationExists(d *DecoyRegistration) *DecoyRegistration {
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	return r.registrationExists(d)
+
+}
+
+// For use inside of this struct (so no deadlocks on struct mutex)
 func (r *RegisteredDecoys) registrationExists(d *DecoyRegistration) *DecoyRegistration {
 
 	t, ok := r.transports[d.Transport]

--- a/application/main.go
+++ b/application/main.go
@@ -181,7 +181,7 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 
 	for {
 
-		newRegs, err := recieve_zmq_message(sub, regManager)
+		newRegs, err := recieve_zmq_message(sub, regManager, conf)
 		if err != nil {
 			logger.Printf("Encountered err when creating Reg: %v\n", err)
 			continue
@@ -262,7 +262,7 @@ func executeHTTPRequest(reg *cj.DecoyRegistration, payload []byte, apiEndpoint s
 	return nil
 }
 
-func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager) ([]*cj.DecoyRegistration, error) {
+func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager, conf *cj.Config) ([]*cj.DecoyRegistration, error) {
 	msg, err := sub.RecvBytes(0)
 	if err != nil {
 		logger.Printf("error reading from ZMQ socket: %v\n", err)
@@ -294,7 +294,7 @@ func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager) ([
 	// Register one or both of v4 and v6 based on support specified by the client
 	var newRegs []*cj.DecoyRegistration
 
-	if parsed.RegistrationPayload.GetV4Support() {
+	if parsed.RegistrationPayload.GetV4Support() && conf.EnableIPv4 {
 		reg, err := regManager.NewRegistration(parsed.RegistrationPayload, &conjureKeys, false, parsed.RegistrationSource)
 		if err != nil {
 			logger.Printf("Failed to create registration: %v", err)
@@ -319,7 +319,7 @@ func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager) ([
 		}
 	}
 
-	if parsed.RegistrationPayload.GetV6Support() {
+	if parsed.RegistrationPayload.GetV6Support() && conf.EnableIPv6{
 		reg, err := regManager.NewRegistration(parsed.RegistrationPayload, &conjureKeys, true, parsed.RegistrationSource)
 		if err != nil {
 			logger.Printf("Failed to create registration: %v", err)

--- a/registration-api/main.go
+++ b/registration-api/main.go
@@ -92,9 +92,8 @@ func (s *server) register(w http.ResponseWriter, r *http.Request) {
 	var clientAddrBytes = make([]byte, 16, 16)
 	if clientAddr != nil {
 		clientAddrBytes = []byte(clientAddr.To16())
-	} else {
-		fmt.Printf("unable to get source address:\"%s\"\n", requestIP)
 	}
+
 	zmqPayload, err := s.processC2SWrapper(payload, clientAddrBytes)
 	if err != nil {
 		s.logger.Println("failed to marshal ClientToStation into VSP:", err)


### PR DESCRIPTION
## Issues

This handles a number of issues that were discovered spontaneously in production

1. go doesn't automatically clean up sockets on interrupt in `zmq_proxy`, which can cause the zmq_proxy thread to crash. This will cause the station to stop ingesting registrations, missing all connections

2. The liveness testing is turned up too high. This results in too many tcp sockets being used concurrently. 

3. Data race in registration tracking because of early tracking and lookup added in #63 

4. `too many files open` causing things to fail with locks, causing deadlock on golang station.

## Solutions 

1. To fix the socket cleanup a defered close is added for the sockets in both directions. This seems to prevent the sockets ending up in a state where they fail to connect and crash the station. 

2.  The number of parallel tcp connections per registration is turned down from 8 to 3. This lowers the absolute confidence that any given phantom is not live, but it should still be sufficient. Also, currenlty no production station supports v6 connection so all ipv6 registrations are wasted. This adds an option to the station config to disable ipv6, so registrations won't be ingested, tracked or have liveness tests performed. This cuts the current number of liveness probes in half as clients always register both v4 and v6 currently but no stations support it. 

3. To prevent the `RegisteredDecoys` struct from stepping on its own mutex, I have added "private" functions for `track` and `registrationExists` which are used by other functions of `RegisteredDecoys`  (i.e. both are used by register). "Public" function equivalents `Track` and `RegistrationExists` have been added to be used by external structs so that the mutex is never stepped on. This seems to work for this issue, preventing both data races and deadlock by mutex abuse.