### PR TITLE
Prod patch2

### DIFF
--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -362,7 +362,9 @@ func phantomIsLive(address string) (bool, error) {
 	// If any return errors or connect then return nil before deadline it is live
 	select {
 	case err := <-dialError:
-		// fmt.Printf("Received: %v\n", err)
+		if e, ok := err.(net.Error); ok && e.Timeout() {
+			return false, "Reached connection timeout"
+		}
 		if err != nil {
 			return true, err
 		}

--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -363,7 +363,7 @@ func phantomIsLive(address string) (bool, error) {
 	select {
 	case err := <-dialError:
 		if e, ok := err.(net.Error); ok && e.Timeout() {
-			return false, "Reached connection timeout"
+			return false, fmt.Errorf("Reached connection timeout")
 		}
 		if err != nil {
 			return true, err

--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -560,15 +560,12 @@ type regExpireLogMsg struct {
 	RegCount   int32
 }
 
-// This whole process of tracking timeouts and registrations separately
-// makes less and less sense every time I come back to it.
-func (r *RegisteredDecoys) removeOldRegistrations(logger *log.Logger) {
+func (r *RegisteredDecoys) getExpiredRegistrations() []string {
+	r.m.RLock()
+	defer r.m.RUnlock()
+
 	const regTimeout = time.Minute * 2
-	cutoff := time.Now().Add(-regTimeout)
-
-	r.m.Lock()
-	defer r.m.Unlock()
-
+	var cutoff = time.Now().Add(-regTimeout)
 	var expiredRegTimeoutIndices = []string{}
 
 	for idx, decoyTimeout := range r.decoysTimeouts {
@@ -579,30 +576,57 @@ func (r *RegisteredDecoys) removeOldRegistrations(logger *log.Logger) {
 		}
 	}
 
+	return expiredRegTimeoutIndices
+}
+
+func (r *RegisteredDecoys) removeRegistration(index string) *regExpireLogMsg {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	expiredReg := r.decoysTimeouts[index]
+	expiredRegObj, ok := r.decoys[expiredReg.decoy][expiredReg.identifier]
+	if !ok {
+		return nil
+	}
+
+	stats := &regExpireLogMsg{
+		DecoyAddr:  expiredReg.decoy,
+		Reg2expire: int64(time.Since(expiredReg.registrationTime) / time.Millisecond),
+		RegID:      expiredReg.regID,
+		RegCount:   expiredRegObj.regCount,
+	}
+
+	// remove from timeout tracking
+	delete(r.decoysTimeouts, index)
+
+	// remove from decoy tracking
+	delete(r.decoys[expiredReg.decoy], expiredReg.identifier)
+
+	// if no more registration exist for this phantom clean up
+	if len(r.decoys[expiredReg.decoy]) == 0 {
+		delete(r.decoys, expiredReg.decoy)
+	}
+
+	return stats
+}
+
+// This whole process of tracking timeouts and registrations separately
+// makes less and less sense every time I come back to it.
+// Note: please try to limit duration that this process is capable of taking the
+// lock on the RegisteredDecoys mutex to prevent thread locking.
+func (r *RegisteredDecoys) removeOldRegistrations(logger *log.Logger) {
+	var expiredRegTimeoutIndices = r.getExpiredRegistrations()
+
 	logger.Printf("cleansing registrations - registrations: %d, timeouts: %d, expired: %d",
 		r.totalRegistrations(), len(r.decoysTimeouts), len(expiredRegTimeoutIndices))
 
 	for _, idx := range expiredRegTimeoutIndices {
-		expiredReg := r.decoysTimeouts[idx]
-		expiredRegObj, ok := r.decoys[expiredReg.decoy][expiredReg.identifier]
-		if !ok {
-			continue
+
+		stats := r.removeRegistration(idx)
+		if stats != nil {
+			statsStr, _ := json.Marshal(stats)
+			logger.Printf("expired registration %s", statsStr)
 		}
-
-		// remove from decoy tracking
-		delete(r.decoys[expiredReg.decoy], expiredReg.identifier)
-		stats := regExpireLogMsg{
-			DecoyAddr:  expiredReg.decoy,
-			Reg2expire: int64(time.Since(expiredReg.registrationTime) / time.Millisecond),
-			RegID:      expiredReg.regID,
-			RegCount:   expiredRegObj.regCount,
-		}
-		statsStr, _ := json.Marshal(stats)
-
-		// remove from timeout tracking
-		delete(r.decoysTimeouts, idx)
-
-		logger.Printf("expired registration %s", statsStr)
 	}
 }
 

--- a/application/main.go
+++ b/application/main.go
@@ -218,7 +218,6 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 				if err != nil {
 					logger.Println("error tracking registration: ", err)
 				}
-				continue
 
 				// If registration is trying to connect to a dark decoy that is blocklisted continue
 				covertStr, _, err := net.SplitHostPort(reg.Covert)


### PR DESCRIPTION
## Issue

Station application is blocking intermittently. It seems to be waiting on the lock for registration tracking.

## Solution 

The (almost certainly) longest duration lookup is the `removeOldRegistrations` function which has multiple steps and is required to iterate through the entire list of registrations. If we are storing a large number of registrations this means a linearly longer time that it holds the lock on registration tracking. 

To fix this I have made the removal of expired registrations modular wrt. the mutex. So now it takes a read lock to itemize and get a list of all expired registrations, then it takes a lock one by one to delete them. This means that the stations should never have to wait an extreme amount of time to get the lock to ingest a new registration. 
 
This PR adds two new functions `getExpiredRegistrations` and `removeRegistration`
