### PR TITLE
Fix ZMQ race condition from proxy

### DIFF
--- a/application/lib/zmq_proxy.go
+++ b/application/lib/zmq_proxy.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"sync"
 	"time"
 
 	zmq "github.com/pebbe/zmq4"
@@ -65,8 +64,7 @@ func ZMQProxy(c ZMQConfig) {
 	}
 	defer pubSock.Close()
 
-	wg := sync.WaitGroup{}
-
+	messages := make(chan []byte)
 	// Create a socket for each socket we're connecting to. I would've
 	// liked to use a single socket for all connections, and ZMQ actually
 	// does support connecting to multiple sockets from a single socket,
@@ -109,18 +107,22 @@ func ZMQProxy(c ZMQConfig) {
 		}
 		defer sock.Close()
 
-		wg.Add(1)
-
-		go func(frontend *zmq.Socket, config socketConfig) {
-			p.logger.Printf("proxying for %s\n", config.Address)
-			e := zmq.Proxy(frontend, pubSock, nil)
-			defer p.logger.Println("[ERROR] zmq.Proxy exiting: ", e)
-			if e != nil {
-				p.logger.Printf("proxy for %s failed: %v\n", config.Address, e)
+		go func(sub *zmq.Socket, config socketConfig) {
+			for {
+				msg, err := sub.RecvBytes(0)
+				if err != nil {
+					p.logger.Printf("read from %s failed: %v\n", config.Address, err)
+					continue
+				}
+				messages <- msg
 			}
 		}(sock, connectSocket)
 	}
 
-	wg.Wait()
-	defer p.logger.Println("[ERROR] zmq.Proxy escaped wg.Wait")
+	for msg := range messages {
+		_, err := pubSock.SendBytes(msg, 0)
+		if err != nil {
+			p.logger.Printf("write to pubSock failed: %v\n", err)
+		}
+	}
 }

--- a/application/lib/zmq_proxy_test.go
+++ b/application/lib/zmq_proxy_test.go
@@ -1,0 +1,119 @@
+package lib
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	zmq "github.com/pebbe/zmq4"
+)
+
+const (
+	numSockets        = 10
+	messagesPerSocket = 10000
+)
+
+func TestConcurrentProxy(t *testing.T) {
+	dir := t.TempDir()
+	keyFilename := filepath.Join(dir, "test_key")
+	keyFile, err := os.Create(keyFilename)
+	if err != nil {
+		panic(err)
+	}
+	// Generate sample Curve25519 key
+	var key [32]byte
+	_, err = io.ReadFull(rand.Reader, key[:])
+	if err != nil {
+		panic(err)
+	}
+	key[0] &= 248
+	key[31] &= 127
+	key[31] |= 64
+	_, err = keyFile.Write(key[:])
+	if err != nil {
+		panic(err)
+	}
+	keyFile.Close()
+
+	config := ZMQConfig{
+		SocketName:        "test-proxying",
+		ConnectSockets:    []socketConfig{},
+		PrivateKeyPath:    keyFilename,
+		HeartbeatInterval: 30000,
+		HeartbeatTimeout:  30000,
+	}
+
+	sockets := make([]*zmq.Socket, numSockets)
+	for i := 0; i < numSockets; i++ {
+		name := fmt.Sprintf("ipc://@test-proxied-%d", i)
+		config.ConnectSockets = append(config.ConnectSockets, socketConfig{
+			Address:            name,
+			AuthenticationType: "NULL",
+			SubscriptionPrefix: "",
+		})
+		sockets[i], err = zmq.NewSocket(zmq.PUB)
+		if err != nil {
+			panic(err)
+		}
+		err = sockets[i].Bind(name)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	go ZMQProxy(config)
+
+	sub, err := zmq.NewSocket(zmq.SUB)
+	if err != nil {
+		panic(err)
+	}
+	sub.SetSubscribe("")
+	err = sub.Connect("ipc://@test-proxying")
+	if err != nil {
+		panic(err)
+	}
+
+	received := 0
+	done := make(chan struct{})
+	go func() {
+		for {
+			_, err := sub.RecvBytes(0)
+			if err != nil {
+				panic(err)
+			}
+			received++
+			if received == numSockets*messagesPerSocket {
+				done <- struct{}{}
+				return
+			}
+		}
+	}()
+
+	time.Sleep(1 * time.Second)
+
+	for i := 0; i < numSockets; i++ {
+		go func(sock *zmq.Socket) {
+			for j := 0; j < messagesPerSocket; j++ {
+				_, err = sock.SendBytes([]byte("test"), 0)
+				if err != nil {
+					panic(err)
+				}
+				time.Sleep(100 * time.Microsecond)
+			}
+		}(sockets[i])
+		// Stagger messages; ZMQ seems to drop non-staggered messages,
+		// and clumps of messages isn't our use-case
+		time.Sleep(10 * time.Microsecond)
+	}
+
+	select {
+	case <-time.After(10 * time.Second):
+		t.Errorf("failed to receive correct number of messages; expected %d, got %d", numSockets*messagesPerSocket, received)
+	case <-done:
+		return
+	}
+}


### PR DESCRIPTION
This PR attempts to fix the race condition caused by proxying to the same `pubSock` from multiple goroutines. It instead feeds all reads from each subscribe socket into one centralized goroutine to publish messages back out. I was able to reproduce the condition of the socket locking up when proxying from multiple goroutines concurrently, and have verified that centralizing the sends fixes that issue. I haven't been able to test this specific change since I took my test environment offline, though it's a fairly straightforward fan-in via a channel.