### PR TITLE
Race Condition in Application Reg tracking.

### DIFF
--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -543,7 +543,15 @@ func (r *RegisteredDecoys) getRegistrations(darkDecoyAddr net.IP) map[string]*De
 	return regs
 }
 
+func (r *RegisteredDecoys) TotalRegistrations() int {
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	return r.totalRegistrations()
+}
+
 func (r *RegisteredDecoys) totalRegistrations() int {
+
 	total := 0
 	for _, regSet := range r.decoys {
 		total += len(regSet)
@@ -563,7 +571,7 @@ func (r *RegisteredDecoys) countRegistrations(darkDecoyAddr net.IP) int {
 	return len(regs)
 }
 
-// For use outside of this struct (so there are no data races.)
+// RegistrationExists - For use outside of this struct only (so there are no data races.)
 func (r *RegisteredDecoys) RegistrationExists(d *DecoyRegistration) *DecoyRegistration {
 	r.m.RLock()
 	defer r.m.RUnlock()
@@ -662,7 +670,7 @@ func (r *RegisteredDecoys) removeOldRegistrations(logger *log.Logger) {
 	var expiredRegTimeoutIndices = r.getExpiredRegistrations()
 
 	logger.Printf("cleansing registrations - registrations: %d, timeouts: %d, expired: %d",
-		r.totalRegistrations(), len(r.decoysTimeouts), len(expiredRegTimeoutIndices))
+		r.TotalRegistrations(), len(r.decoysTimeouts), len(expiredRegTimeoutIndices))
 
 	for _, idx := range expiredRegTimeoutIndices {
 


### PR DESCRIPTION
## Issue 
race condition caused by un-locked `totalRegistrations` count method. 

## Solution

Add a wrapping function that can be accessed from outside the struct that locks before counting all registrations. Any functions using the private `totalRegistrations` function will not lock (potentially a second time causing deadlock). Any functions only using the public `TotalRegistrations`  function will lock preventing data race conditions. 

In the logs this occurred because of a call to `totalRegistrations` in `removeOldRegistrations`, which is a special case where we use the external functions to lock for piecewise progress so that the function doesn't hold a lock on the struct for long periods of time while cleaning up. 

## logs
```
Feb 10 14:29:03 conjure[9125]: ==================
Feb 10 14:29:03 conjure[9125]: [REG] 2021/02/10 14:29:03.320552 cleansing registrations - registrations: 1618, timeouts: 1618, expired: 981
Feb 10 14:29:03 conjure[9125]: WARNING: DATA RACE
Feb 10 14:29:03 conjure[9125]: Write at 0x00c00012d680 by goroutine 102:
Feb 10 14:29:03 conjure[9125]:   runtime.mapassign_faststr()
Feb 10 14:29:03 conjure[9125]:       /usr/local/go/src/runtime/map_faststr.go:202 +0x0
Feb 10 14:29:03 conjure[9125]:   github.com/refraction-networking/conjure/application/lib.(*RegisteredDecoys).track()
Feb 10 14:29:03 conjure[9125]:       /home/jmwample/go/src/github.com/refraction-networking/conjure/application/lib/registration.go:480 +0x690
Feb 10 14:29:03 conjure[9125]:   github.com/refraction-networking/conjure/application/lib.(*RegisteredDecoys).Track()
Feb 10 14:29:03 conjure[9125]:       /home/jmwample/go/src/github.com/refraction-networking/conjure/application/lib/registration.go:453 +0xa6
Feb 10 14:29:03 conjure[9125]:   github.com/refraction-networking/conjure/application/lib.(*RegistrationManager).TrackRegistration()
Feb 10 14:29:03 conjure[9125]:       /home/jmwample/go/src/github.com/refraction-networking/conjure/application/lib/registration.go:200 +0x41a
Feb 10 14:29:03 conjure[9125]:   main.get_zmq_updates.func1()
Feb 10 14:29:03 conjure[9125]:       /home/jmwample/conjure/application/main.go:216 +0x42e
Feb 10 14:29:03 conjure[9125]: Previous read at 0x00c00012d680 by goroutine 9:
Feb 10 14:29:03 conjure[9125]:   runtime.mapiterinit()
Feb 10 14:29:03 conjure[9125]:       /usr/local/go/src/runtime/map.go:797 +0x0
Feb 10 14:29:03 conjure[9125]:   github.com/refraction-networking/conjure/application/lib.(*RegisteredDecoys).totalRegistrations()
Feb 10 14:29:03 conjure[9125]:       /home/jmwample/go/src/github.com/refraction-networking/conjure/application/lib/registration.go:548 +0xb1
Feb 10 14:29:03 conjure[9125]:   github.com/refraction-networking/conjure/application/lib.(*RegisteredDecoys).removeOldRegistrations()
Feb 10 14:29:03 conjure[9125]:       /home/jmwample/go/src/github.com/refraction-networking/conjure/application/lib/registration.go:665 +0x7a
Feb 10 14:29:03 conjure[9125]:   github.com/refraction-networking/conjure/application/lib.(*RegistrationManager).RemoveOldRegistrations()
Feb 10 14:29:03 conjure[9125]:       /home/jmwample/go/src/github.com/refraction-networking/conjure/application/lib/registration.go:237 +0x84
Feb 10 14:29:03 conjure[9125]:   main.main.func1()
Feb 10 14:29:03 conjure[9125]:       /home/jmwample/conjure/application/main.go:406 +0x85
Feb 10 14:29:03 conjure[9125]: Goroutine 102 (running) created at:
Feb 10 14:29:03 conjure[9125]:   main.get_zmq_updates()
Feb 10 14:29:03 conjure[9125]:       /home/jmwample/conjure/application/main.go:193 +0x33a
Feb 10 14:29:03 conjure[9125]: Goroutine 9 (running) created at:
Feb 10 14:29:03 conjure[9125]:   main.main()
Feb 10 14:29:03 conjure[9125]:       /home/jmwample/conjure/application/main.go:403 +0x6cd
Feb 10 14:29:03 conjure[9125]: ==================
```