### PR TITLE
Explicitly drop lock in Sessions.rs

### DIFF
--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -364,6 +364,10 @@ fn ingest_from_pubsub(map: Arc<RwLock<HashMap<String, u64>>>) {
                 },
                 None => {},
             };
+
+            // Explicitly drop map write lock here (locks are automatically dropped
+            // when they fall out of scope but this is more clear.)
+            drop(mmap);
             continue
         }
 
@@ -373,7 +377,8 @@ fn ingest_from_pubsub(map: Arc<RwLock<HashMap<String, u64>>>) {
         // Insert
         *mmap.entry(key).or_insert(expire_time) = expire_time;
 
-        // Get rid of writable reference to map.
+        // Get rid of writable reference to map. (locks are automatically dropped
+        // when they fall out of scope but this is more clear.)
         drop(mmap);
 
         debug!("Added registered ip {} from redis", sd);


### PR DESCRIPTION
## Issue

Session tracking doesn't explicitly drop the lock when managing sessions [here](https://github.com/refraction-networking/conjure/blob/dd2e1bcdb474b385d9251ed0495ea5fda8248c13/src/sessions.rs#L365). This isn't necessary a problem because locks are implicitly dropped when they fall out of scope. 

## Solution

Explicitly drop the reference to the map so that we do not have to worry about revisiting this later. This is passing the test that triggers the conditional statement at line 354 (session exists). 