### PR TITLE
Docker and Related

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+docker
+!docker/*
+docker/Dockerfile
+docker/docker-compose*
+docker/.dockerignore
+docker/*.swp
+.dockerignore
+*.swp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,81 @@
+FROM ubuntu:20.04 as build_base
+#    PATH="/opt/PF_RING/userland/examples_zc:$PATH"
+
+#wget make gcc bison flex
+RUN apt-get update && \
+    apt-get -y -q install wget git make gcc bison flex && \
+    git clone --recurse-submodule https://github.com/refraction-networking/conjure.git && \
+    cd /conjure/PF_RING/userland/lib && ./configure && make && \
+    cd /conjure/PF_RING/userland/libpcap && ./configure && make && \
+    cd /conjure/PF_RING/userland && ./configure && make && \
+    cp -r /conjure/PF_RING /opt/PF_RING && \
+    apt-get clean all
+
+FROM build_base as build_base_go
+ARG GO_VERSION=1.15.3
+ARG CUSTOM_BUILD
+ENV PATH="/usr/local/go/bin:/root/.cargo/bin:${PATH}" \
+    GOPATH="/root/go" \
+    GOROOT="/usr/local/go"
+COPY . /tmp/conjure
+
+
+# Install rust and go
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get -y -q install protobuf-compiler curl libssl-dev pkg-config libgmp3-dev libzmq3-dev && \
+    wget -q https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
+    curl https://sh.rustup.rs -sSf -o install_rust.sh; sh install_rust.sh -y && \
+    cargo install protobuf-codegen
+
+RUN go get -u -d github.com/go-redis/redis || true && cd ${GOPATH}/src/github.com/go-redis/redis && git checkout tags/v7.4.0 -b v7-master 
+RUN    go get -u -d github.com/BurntSushi/toml 
+RUN    bash -c 'if [[ -z "$CUSTOM_BUILD" ]] ; then \
+     go get -d github.com/refraction-networking/conjure/...  ; \
+     else mkdir -p ${GOPATH}/src/github.com/refraction-networking; cp -r /tmp/conjure ${GOPATH}/src/github.com/refraction-networking/conjure ; \
+     fi' 
+RUN    rm -rf ${GOPATH}/src/github.com/refracion-networking/conjure/PF_RING && cp -r /conjure/PF_RING ${GOPATH}/src/github.com/refraction-networking/conjure 
+RUN    cd /root/go/src/github.com/refraction-networking/conjure && \
+    go get ./... || true && \
+    make 
+RUN    cp -r /root/go/src/github.com/refraction-networking/conjure /opt/conjure
+
+
+
+
+FROM ubuntu:20.04 as zbalance
+ENV CJ_IFACE=lo \
+    CJ_CLUSTER_ID=98 \
+    CJ_CORECOUNT=1 \
+    CJ_COREBASE=0 \
+    ZBALANCE_HASH_MODE=1
+COPY --from=build_base /opt/PF_RING /opt/PF_RING
+COPY ./docker/zbalance-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["bash", "/entrypoint.sh"]
+
+FROM ubuntu:20.04 as detector
+ENV CJ_CLUSTER_ID=98 \
+    CJ_CORECOUNT=1 \
+    CJ_COREBASE=0 \
+    CJ_SKIP_CORE=-1 \
+    CJ_QUEUE_OFFSET=0 \
+    CJ_LOG_INTERVAL=5 \
+    CJ_PRIVKEY=/opt/conjure/keys/privkey \
+    CJ_STATION_CONFIG=/opt/conjure/application/config.toml \
+    CJ_IP4_ADDR=127.0.0.1 \
+    CJ_IP6_ADDR=[::1]
+COPY --from=build_base_go /opt/conjure/dark-decoy /opt/conjure/dark-decoy
+COPY --from=build_base_go /opt/conjure/application/config.toml /opt/conjure/application/config.toml
+COPY ./docker/detector-entrypoint.sh /entrypoint.sh
+# this list will be removed in a near future
+RUN touch /var/lib/dark-decoy.prefixes
+
+RUN apt-get update && apt-get -y -q install libzmq3-dev iproute2 iptables && apt-get clean all
+ENTRYPOINT [ "/entrypoint.sh"]
+
+FROM ubuntu:20.04 as application
+ENV CJ_STATION_CONFIG=/opt/conjure/application/config.toml
+COPY --from=build_base_go /opt/conjure/application/application /opt/conjure/application/application
+RUN apt-get update && apt-get -y -q install libzmq3-dev
+COPY --from=build_base_go /opt/conjure/application/config.toml ${CJ_STATION_CONFIG}
+#COPY ./docker/application-entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/opt/conjure/application/application"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,58 @@
+Before running the app PF_RING kernel module and hugepages need to be configured on the host system
+
+#### PF_RING Kernel Module
+Ntop does not maintain versioning of the PF_RING so the only way to get any other than latest PF_RING version it needs to be compiled from source.  
+Since since this is going to be used by Conjure station it makes sense to use PF_RING version included in Conjure repository.  
+
+```
+git clone --recursive https://github.com/refraction-networking/conjure.git
+cd conjure/PF_RING/kernel
+apt install make gcc flex bison
+make clean && make
+make install
+```
+Now load the kernel module and make it persist over reboots.  
+```
+insmod pf_ring.ko min_num_slots=65536
+echo pf_ring.ko min_num_slots=65536 >> /etc/modules
+```
+
+Next, compile and load NIC driver 
+```
+# Determine the driver family
+ethtool -i eth1 | grep driver
+> ixgbe
+
+# Compile and load the corresponding driver
+cd PF_RING/drivers/intel
+make
+cd ixgbe/ixgbe-*-zc/src
+./load_driver.sh
+```
+To confirm that driver is loaded run   
+```
+cat /proc/net/pf_ring/dev/<IntName>/info | grep ZC
+```
+
+#### Hugepages
+There are multiple places to configure it: in pf_ring hugepages.conf file, in a script that gets run before conjure service, on a system startup etc..  
+Host system configuration:
+```
+sysctl -w vm.nr_hugepages=512
+echo "vm.nr_hugepages=512" >> /etc/sysctl.conf
+```
+
+#### Running Conjure
+Dockerfile supports two sources to build from: original conjure repository from github or local source code. Default is to use original github repository. To use local source code set CUSTOM_BUILD build argument and rebuild the images. Build argument can be set by appending `--build-arg CUSTOM_BUILD=1` to `docker build` or by setting in docker-compose build like so:
+```
+    service:
+      build:
+        args:
+          CUSTOM_BUILD: "1"
+```
+
+##### Configuration
+Set CJ_IFACE variable to the name of the network interface that receives conjure traffic. Easiest way is just edit the docker-file and change CJ_IFACE in `zbalance` service
+
+##### Run
+`docker-compose up -d`

--- a/docker/README.md
+++ b/docker/README.md
@@ -56,3 +56,28 @@ Set CJ_IFACE variable to the name of the network interface that receives conjure
 
 ##### Run
 `docker-compose up -d`
+
+#### List of Supported Variables and Defaults
+```
+# zbalance
+CJ_IFACE=lo
+CJ_CLUSTER_ID=98
+CJ_CORECOUNT=1
+CJ_COREBASE=0
+ZBALANCE_HASH_MODE=1
+
+# detector
+CJ_CLUSTER_ID=98
+CJ_CORECOUNT=1
+CJ_COREBASE=0
+CJ_SKIP_CORE=-1
+CJ_QUEUE_OFFSET=0
+CJ_LOG_INTERVAL=5
+CJ_PRIVKEY=/opt/conjure/keys/privkey
+CJ_STATION_CONFIG=/opt/conjure/application/config.toml
+CJ_IP4_ADDR=127.0.0.1
+CJ_IP6_ADDR=[::1]
+
+# application
+CJ_STATION_CONFIG=/opt/conjure/application/config.toml
+```

--- a/docker/detector-entrypoint.sh
+++ b/docker/detector-entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+CORE_COUNT=${CJ_CORECOUNT:-2}
+OFFSET=${CJ_QUEUE_OFFSET:-2}
+
+cleanup() {
+  echo $(ps aux)
+  start-stop-daemon --stop --oknodo --retry 15 -n dark-decoy
+  #pkill dark-decoy
+  echo $(ps aux)
+  for CORE in `seq $OFFSET $((OFFSET + CORE_COUNT -1 ))`
+  do
+    echo "Cleaning up"
+    tun_int=tun${CORE}
+    ip6tables -D INPUT -i ${tun_int} -j ACCEPT
+    ip6tables -t nat -D PREROUTING -p tcp -i ${tun_int} -j DNAT --to ${CJ_IP6_ADDR}:41245
+    iptables -D INPUT -i ${tun_int} -j ACCEPT
+    iptables -t nat -D PREROUTING -p tcp -i ${tun_int} -j DNAT --to ${CJ_IP4_ADDR}:41245
+    ip tuntap del mode tun ${tun_int}
+  done
+}
+
+trap 'true' SIGTERM
+
+
+sysctl -w net.ipv4.conf.all.route_localnet=1
+sysctl -w net.ipv4.conf.all.rp_filter=0
+
+for CORE in `seq $OFFSET $((OFFSET + CORE_COUNT -1 ))`
+do
+  tun_int=tun${CORE}
+  if [[ -f /sys/class/net/${tun_int}/tun_flags ]]
+  then
+    echo "Tunnel ${tun_int} found. Skipping creation."
+  else
+    ip tuntap add mode tun ${tun_int}
+  fi
+  sysctl -w net.ipv4.conf.${tun_int}.rp_filter=0
+  sysctl -w net.ipv4.conf.${tun_int}.route_localnet=1
+
+  rules=$(iptables -t nat -L PREROUTING -v|grep ${tun_int})
+  if [ $? == 0 ]
+  then
+    echo "The following iptables rules were found for ${tun_int}:"
+    echo ${rules}
+    echo
+    echo "Skipping ipv4 firewall configuration for ${tun_int}"
+  else
+    echo "Adding iptables rules for ${tun_int}"
+    iptables -t nat -I PREROUTING 1 -p tcp -i ${tun_int} -j DNAT --to ${CJ_IP4_ADDR}:41245
+    iptables -I INPUT 1 -i ${tun_int} -j ACCEPT
+  fi
+
+  rules=$(ip6tables -t nat -L PREROUTING -v|grep ${tun_int})
+  if [ $? == 0 ]
+  then
+    echo "The following ip6tables rules were found for ${tun_int}:"
+    echo ${rules}
+    echo
+    echo "Skipping ipv6 firewall configuration for ${tun_int}"
+  else
+    echo "Adding ip6tables rules for ${tun_int}"
+    ip6tables -t nat -I PREROUTING 1 -p tcp -i ${tun_int} -j DNAT --to ${CJ_IP6_ADDR}:41245
+    ip6tables -I INPUT 1 -i ${tun_int} -j ACCEPT
+  fi
+done
+echo "Prerequisite configuration complete."
+/opt/conjure/dark-decoy -c ${CJ_CLUSTER_ID} -o ${CJ_COREBASE} -n ${CJ_CORECOUNT} -l ${CJ_LOG_INTERVAL} -K ${CJ_PRIVKEY} -s ${CJ_SKIP_CORE} -z ${CJ_QUEUE_OFFSET} &
+wait $!
+cleanup
+
+

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,64 @@
+version: '3.4'
+services:
+    # zbalance needs access to the monitored interface and to systems hugepages.
+    # hugepages are shared between containers
+    # `network_mode: host` and `privileged: true` make it possible
+    # but it might be possible to achieve with 'docker capabilities'
+  
+    zbalance:
+        image: zbalance:latest
+        build:
+                context: ../
+                dockerfile: ./docker/Dockerfile
+                target: zbalance
+        #cap_add: 
+        #  - SYS_ADMIN
+        privileged: true
+        environment:
+                - CJ_IFACE=eno3
+        volumes:
+                - /dev/hugepages:/dev/hugepages
+                - /etc/pf_ring:/etc/pf_ring
+        restart: unless-stopped
+        network_mode: "host"
+    redis:
+        image: redis:alpine
+        restart: unless-stopped
+        depends_on:
+                - zbalance
+        # Redis has to be exposed on localhost. Check 'detector' service for details
+        network_mode: "host"
+    detector:
+        image: detector:latest
+        build:
+                context: ../
+                dockerfile: ./docker/Dockerfile
+                target: detector
+        # For hugepages to work
+        privileged: true
+        environment:
+                - RUST_BACKTRACE=1
+                - LOG_CLIENT_IP=true
+        volumes:
+                - /dev/hugepages:/dev/hugepages
+                - /var/lib/tapdance/prod.privkey:/opt/conjure/keys/privkey
+        depends_on:
+                - zbalance
+                - redis
+        restart: unless-stopped
+        # To connect to reddis. See line 200 in src/flow_tracker.rs
+        network_mode: "host"
+    application:
+        image: application:latest
+        build:
+                context: ../
+                dockerfile: ./docker/Dockerfile
+                target: application
+        environment:
+                - LOG_CLIENT_IP=true
+        volumes:
+                - /var/lib/tapdance/prod.privkey:/opt/conjure/sysconfig/privkey
+        depends_on:
+                - zbalance
+                - detector
+        network_mode: "host"

--- a/docker/simple-entrypoint.sh
+++ b/docker/simple-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+exec "$@"

--- a/docker/start_zbalance_ipc.sh
+++ b/docker/start_zbalance_ipc.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Run zbalance. Needed for zero-copy mode Tapdance
+# See README.md
+source /opt/conjure/sysconfig/conjure.conf
+
+ZBALANCE_HASH_MODE=1
+# If the target is not the zero-copy tapdance, don't run zbalance
+#if [[ "x${TD_TARGET}" != "xzc_tapdance"  && "x${TD_TARGET}" != "xzmq_tapdance" ]]; then
+#    exit 0
+#fi
+
+# TD_IFACE could be a CSV list of interfaces.
+# Pull them apart to ensure each gets zc: prefix
+ifcarg=""
+IFS=',' read -r -a ifcarray <<< "${CJ_IFACE}"
+didfirst=0
+for ifc in "${ifcarray[@]}"
+do
+    ifcelem="zc:${ifc}"
+    if [[ $ifc = "zc:"* ]]; then
+	ifcelem=${ifc}
+    fi
+    if [ $didfirst -ne 0 ]; then
+	ifcarg="$ifcarg,$ifcelem"
+    else
+	ifcarg=$ifcelem
+	didfirst=1
+    fi
+done
+echo "Setting up with params: -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE}"
+/opt/conjure/PF_RING/userland/examples_zc/zbalance_ipc -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE}
+

--- a/docker/zbalance-entrypoint.sh
+++ b/docker/zbalance-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# TD_IFACE could be a CSV list of interfaces.
+# Pull them apart to ensure each gets zc: prefix
+ifcarg=""
+IFS=',' read -r -a ifcarray <<< "${CJ_IFACE}"
+didfirst=0
+for ifc in "${ifcarray[@]}"
+do
+    ifcelem="zc:${ifc}"
+    if [[ $ifc = "zc:"* ]]; then
+        ifcelem=${ifc}
+    fi
+    if [ $didfirst -ne 0 ]; then
+        ifcarg="$ifcarg,$ifcelem"
+    else
+        ifcarg=$ifcelem
+        didfirst=1
+    fi
+done
+echo "Setting up with params: -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE}"
+/opt/PF_RING/userland/examples_zc/zbalance_ipc -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE}


### PR DESCRIPTION
* Added multistage Dockerfile for each service (except registration)
* Added Readme with a quick start information
* Added detector-entrypoint.sh which includes routing and tun interface configuration (similar to on-reboot.sh)
* Added simple entrypoints for other services
* Added docker-compose.yaml with sample configuration and mandatory variables

Major difference is DNAT-ing to localhost instead of public IP by default and enabling net.ipv4.conf.all.route_localnet. This simplifies minimum required configuration.

All files (except .dockerignore) are in a separate directory so it should not have any impact on current deployment procedures.