### PR TITLE
Change phantom_blocklist behavior

### DIFF
--- a/application/main.go
+++ b/application/main.go
@@ -238,6 +238,12 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 					go tryShareRegistrationOverAPI(reg, conf.PreshareEndpoint)
 				}
 
+
+				if conf.IsBlocklistedPhantom(reg.DarkDecoy) {
+					logger.Printf("ignoring registration with blocklisted phantom: %s %v", reg.IDString(), reg.DarkDecoy)
+					continue
+				}
+
 				// validate the registration
 				regManager.AddRegistration(reg)
 				logger.Printf("Adding registration %v\n", reg.IDString())
@@ -328,14 +334,9 @@ func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager, co
 			logger.Printf("Failed to create registration: %v", err)
 			return nil, err
 		}
-		if conf.IsBlocklistedPhantom(reg.DarkDecoy) {
-			logger.Printf("ignoring registration with blocklisted phantom: %s %v", reg.IDString(), reg.DarkDecoy)
 
-		} else {
-			// Received new registration, parse it and return
-			newRegs = append(newRegs, reg)
-		}
-
+		// Received new registration, parse it and return
+		newRegs = append(newRegs, reg)
 	}
 
 	if parsed.GetRegistrationPayload().GetV6Support() && conf.EnableIPv6 {
@@ -344,12 +345,8 @@ func recieve_zmq_message(sub *zmq.Socket, regManager *cj.RegistrationManager, co
 			logger.Printf("Failed to create registration: %v", err)
 			return nil, err
 		}
-		if conf.IsBlocklistedPhantom(reg.DarkDecoy) {
-			logger.Printf("ignoring registration with blocklisted phantom: %s %v", reg.IDString(), reg.DarkDecoy)
-		} else {
-			// add to list of new registrations to be processed.
-			newRegs = append(newRegs, reg)
-		}
+		// add to list of new registrations to be processed.
+		newRegs = append(newRegs, reg)
 	}
 
 	// log decoy connection and id string

--- a/application/main.go
+++ b/application/main.go
@@ -240,6 +240,9 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 
 
 				if conf.IsBlocklistedPhantom(reg.DarkDecoy) {
+					// Note: Phantom blocklist is applied at this stage because the phantom may only be blocked on this
+					// station. We may want other stations to be informed about the registration, but prevent this station
+					// specifically from handling / interfering in any subsequent connection. See PR #75
 					logger.Printf("ignoring registration with blocklisted phantom: %s %v", reg.IDString(), reg.DarkDecoy)
 					continue
 				}


### PR DESCRIPTION
When a station receives a registration for a phantom in its phantom_blocklist, currently it is ignored (no liveness check, not shared with registration API, not added to local regManager).

This changes the behavior so that if we get a registration for a phantom in the phantom_blocklist, the registration is tracked, a liveness check is done, and it is shared with the registration API. We still do not add it to the local regManager, so this station won't pickup the connection (and our detector should still ignore it).

We want this because sometimes a station sees lots of decoys / registrations, and we want the central API to hear about them too, but we do not want that particular station to answer for those phantoms (e.g. they all go past another station).