### PR TITLE
Handle client addreses in proxied X-Forwarded-For headers

### DIFF
--- a/registration-api/api_test.go
+++ b/registration-api/api_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	zmq "github.com/pebbe/zmq4"
 	pb "github.com/refraction-networking/gotapdance/protobuf"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -332,4 +333,22 @@ func BenchmarkRegistration(b *testing.B) {
 		w := httptest.NewRecorder()
 		s.register(w, r)
 	}
+}
+
+func TestAPIGetClientAddr(t *testing.T) {
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.Nil(t, err)
+
+	req.RemoteAddr = "10.0.0.0"
+	require.Equal(t, "10.0.0.0", getRemoteAddr(req))
+
+	req.Header.Add("X-Forwarded-For", "192.168.1.1")
+	require.Equal(t, "192.168.1.1", getRemoteAddr(req))
+
+	req.Header.Set("X-Forwarded-For", "127.0.0.1, 192.168.0.0")
+	require.Equal(t, "127.0.0.1", getRemoteAddr(req))
+
+	req.Header.Set("X-Forwarded-For", "127.0.0.1,192.168.0.0")
+	require.Equal(t, "127.0.0.1", getRemoteAddr(req))
 }


### PR DESCRIPTION
## Issue

Currently stations require inclusion of client addresses in registration tracking to limit the interference with non-affiliated traffic. However, the registration API was drawing this directly from the requests remote source address, or attempting to use the `X-Forwarded-For` header as a whole as an address. This breaks things when a registration received over the registration API is sent through a proxy. 

## Solution
I have added parsing for extended X-Forwarded-For headers to allow proxy API registration in ipv4.


Note: In the future we may want to add support for the `True-Client-Ip` header, but this is sufficient for now.