### PR TITLE
Disentangle API registration counts

### DIFF
--- a/application/lib/stats.go
+++ b/application/lib/stats.go
@@ -17,14 +17,15 @@ type Stats struct {
 	newConns    int64 // new connections since last stats.reset()
 	newErrConns int64 // new connections that had some sort of error since last reset()
 
-	activeRegistrations    int64 // Current number of active registrations we have
-	newLocalRegistrations  int64 // Current registrations that were picked up from this detector (also included in newRegistrations)
-	newApiRegistrations    int64 // Current registrations that we heard about from the API (also included in newRegistrations)
-	newRegistrations       int64 // Added registrations since last reset()
-	newMissedRegistrations int64 // number of "missed" registrations (as seen by a connection with no registration)
-	newErrRegistrations    int64 // number of registrations that had some kinda error
-	newDupRegistrations    int64 // number of duplicate registrations (doesn't uniquify, so might have some double counting)
-
+	activeRegistrations     int64 // Current number of active registrations we have
+	newLocalRegistrations   int64 // Current registrations that were picked up from this detector (also included in newRegistrations)
+	newApiRegistrations     int64 // Current registrations that we heard about from the API (also included in newRegistrations)
+	newSharedRegistrations  int64 // Current registrations that we heard about from the API sharing system (also included in newRegistrations)
+	newUnknownRegistrations int64 // Current registrations that we heard about with unknown source (also included in newRegistrations)a
+	newRegistrations        int64 // Added registrations since last reset()
+	newMissedRegistrations  int64 // number of "missed" registrations (as seen by a connection with no registration)
+	newErrRegistrations     int64 // number of registrations that had some kinda error
+	newDupRegistrations     int64 // number of duplicate registrations (doesn't uniquify, so might have some double counting)
 
 	newLivenessPass int64 // Liveness tests that passed (non-live phantom) since reset()
 	newLivenessFail int64 // Liveness tests that failed (live phantom) since reset()
@@ -70,6 +71,8 @@ func (s *Stats) Reset() {
 	atomic.StoreInt64(&s.newRegistrations, 0)
 	atomic.StoreInt64(&s.newLocalRegistrations, 0)
 	atomic.StoreInt64(&s.newApiRegistrations, 0)
+	atomic.StoreInt64(&s.newSharedRegistrations, 0)
+	atomic.StoreInt64(&s.newUnknownRegistrations, 0)
 	atomic.StoreInt64(&s.newMissedRegistrations, 0)
 	atomic.StoreInt64(&s.newErrRegistrations, 0)
 	atomic.StoreInt64(&s.newDupRegistrations, 0)
@@ -80,11 +83,11 @@ func (s *Stats) Reset() {
 }
 
 func (s *Stats) PrintStats() {
-	s.logger.Printf("Conns: %d cur %d new %d err Regs: %d cur %d new (%d local %d API) %d miss %d err %d dup LiveT: %d valid %d live Byte: %d up %d down",
+	s.logger.Printf("Conns: %d cur %d new %d err Regs: %d cur %d new (%d local %d API %d shared %d unknown) %d miss %d err %d dup LiveT: %d valid %d live Byte: %d up %d down",
 		atomic.LoadInt64(&s.activeConns), atomic.LoadInt64(&s.newConns), atomic.LoadInt64(&s.newErrConns),
 		atomic.LoadInt64(&s.activeRegistrations),
 		atomic.LoadInt64(&s.newRegistrations),
-		atomic.LoadInt64(&s.newLocalRegistrations), atomic.LoadInt64(&s.newApiRegistrations),
+		atomic.LoadInt64(&s.newLocalRegistrations), atomic.LoadInt64(&s.newApiRegistrations), atomic.LoadInt64(&s.newSharedRegistrations), atomic.LoadInt64(&s.newUnknownRegistrations),
 		atomic.LoadInt64(&s.newMissedRegistrations),
 		atomic.LoadInt64(&s.newErrRegistrations), atomic.LoadInt64(&s.newDupRegistrations),
 		atomic.LoadInt64(&s.newLivenessPass), atomic.LoadInt64(&s.newLivenessFail),
@@ -113,9 +116,15 @@ func (s *Stats) AddReg(generation uint32, source *pb.RegistrationSource) {
 	if *source == pb.RegistrationSource_Detector {
 		//atomic.AddInt64(&s.activeLocalRegistrations, 1) // Actually an absolute is not super useful.
 		atomic.AddInt64(&s.newLocalRegistrations, 1)
-	} else {
+	} else if *source == pb.RegistrationSource_API {
 		//atomic.AddInt64(&s.activeApiRegistrations, 1)
 		atomic.AddInt64(&s.newApiRegistrations, 1)
+	} else if *source == pb.RegistrationSource_DetectorPrescan {
+		//atomic.AddInt64(&s.activeApiRegistrations, 1)
+		atomic.AddInt64(&s.newSharedRegistrations, 1)
+	} else {
+		//atomic.AddInt64(&s.activeApiRegistrations, 1)
+		atomic.AddInt64(&s.newUnknownRegistrations, 1)
 	}
 	s.genMutex.Lock()
 	s.generations[generation] += 1


### PR DESCRIPTION
## Issue

The current stats track API and DetectorPrescan registration sources as the same thing. Now that we are rolling out some API registrations it would be nice to be able to see that count accurately

## Solution

Separate out the registration sources to track all individually. Will require an update to the log parsing systems. 