### PR TITLE
Update default registration timeout to support registration caching

### DIFF
--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -633,7 +633,7 @@ func (r *RegisteredDecoys) getExpiredRegistrations() []string {
 	r.m.RLock()
 	defer r.m.RUnlock()
 
-	const regTimeout = time.Minute * 2
+	const regTimeout = time.Hour * 6
 	var cutoff = time.Now().Add(-regTimeout)
 	var expiredRegTimeoutIndices = []string{}
 
@@ -712,7 +712,7 @@ func registerForDetector(reg *DecoyRegistration) {
 		return
 	}
 
-	duration := uint64(3 * time.Minute.Nanoseconds())
+	duration := uint64(6 * time.Hour.Nanoseconds())
 	src := reg.registrationAddr.String()
 	phantom := reg.DarkDecoy.String()
 	msg := &pb.StationToDetector{


### PR DESCRIPTION
## Issue

The timeout currently hard-coded for garbage collection of registrations is fixed at a short time period. This doesn't allow clients to cache and re-use registrations for very long.  

## Solution

Update hard-coded default registration tracking timeout from 2 mins to 6 hrs. This is an intermediary step between no caching and caching with aggressive timeouts as described in #83