### PR TITLE
Protobuf rust inner attributes error with rust-1.52.1

### DIFF
--- a/src/signalling.rs
+++ b/src/signalling.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::all)]
 
 #![allow(unused_attributes)]
-#![rustfmt::skip]
 
 #![allow(box_pointers)]
 #![allow(dead_code)]


### PR DESCRIPTION
## Issue

Rust version 1.52.1 considers inner attributes as unstable and throws an error during compile. Protoc rust generation currently uses inner attributes in the generated code. 

```log
error: custom inner attributes are unstable
 --> src/signalling.rs:9:4
  |
9 | #![rustfmt::skip]
  |    ^^^^^^^^^^^^^
  |
  = note: `#[deny(soft_unstable)]` on by default
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>

error: aborting due to previous error

error: could not compile `rust_dark_decoy`
```

## Solution

To fix this for now we manually remove inner attribute set by protoc which causes the error in `cargo build` with rust 1.52.1. This is a temporary fix until protoc has a more stable update that doesn't automatically include inner attributes in the generated files. 

For now the manual solution is a one-time fix as the `signaling.rs` file is not regenerated during station compile. 