### PR TITLE
Address mis-counts in stations application metrics

### DIFF
--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -633,8 +633,10 @@ func (r *RegisteredDecoys) removeRegistration(index string) *regExpireLogMsg {
 		RegCount:   expiredRegObj.regCount,
 	}
 
-	// Update stats
-	Stat().ExpireReg(expiredRegObj.DecoyListVersion, expiredRegObj.RegistrationSource)
+	if expiredRegObj.Valid {
+		// Update stats
+		Stat().ExpireReg(expiredRegObj.DecoyListVersion, expiredRegObj.RegistrationSource)
+	}
 
 	// remove from timeout tracking
 	delete(r.decoysTimeouts, index)


### PR DESCRIPTION
The station application was miscouting both activeRegistrations and
newErrConns. This PR fixes both issues.

* The activeRegistrations we being incremented only for valid
registrations, but decremented for all retired registrations. This is
fixed by checking the validity when calling ExpireReg(...).

* newErrorConns wsa increasing monotonically because it was never added
to Reset() despite being a periodic metric.