### PR TITLE
Docker support local config files & multiple PF_RING ifacs.

### DIFF
--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,11 @@
+#Ignore unused dirs
+PF_Ring/
+paper/
+target/
+
+#Ignoring git and cache folders
+.git
+.cache
+
+#Ignoring all the markdown and class files
+*.md

--- a/docker/detector-entrypoint.sh
+++ b/docker/detector-entrypoint.sh
@@ -2,6 +2,7 @@
 
 CORE_COUNT=${CJ_CORECOUNT:-2}
 OFFSET=${CJ_QUEUE_OFFSET:-2}
+SKIP_CORE=${CJ_SKIP_CORE:0}
 
 cleanup() {
   echo $(ps aux)
@@ -65,7 +66,7 @@ do
   fi
 done
 echo "Prerequisite configuration complete."
-/opt/conjure/conjure -c ${CJ_CLUSTER_ID} -o ${CJ_COREBASE} -n ${CJ_CORECOUNT} -l ${CJ_LOG_INTERVAL} -K ${CJ_PRIVKEY} -s ${CJ_SKIP_CORE} -z ${CJ_QUEUE_OFFSET} &
+/opt/conjure/conjure -c ${CJ_CLUSTER_ID} -o ${CJ_COREBASE} -n ${CJ_CORECOUNT} -l ${CJ_LOG_INTERVAL} -K ${CJ_PRIVKEY} -s ${SKIP_CORE} -z ${CJ_QUEUE_OFFSET} &
 wait $!
 cleanup
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -12,8 +12,7 @@ services:
                 dockerfile: ./docker/Dockerfile
                 target: zbalance
         privileged: true
-        environment:
-                - CJ_IFACE=eno3
+        env_file: /etc/conjure/conjure.conf
         volumes:
                 - /dev/hugepages:/dev/hugepages
                 - /etc/pf_ring:/etc/pf_ring
@@ -34,12 +33,12 @@ services:
                 target: detector
         # For hugepages to work
         privileged: true
-        environment:
-                - RUST_BACKTRACE=1
-                - LOG_CLIENT_IP=true
+        env_file: /etc/conjure/conjure.conf
         volumes:
+                - /etc/conjure/app-config.toml:/opt/conjure/application/config.toml
+                - /etc/conjure/privkey:/opt/conjure/sysconfig/privkey
+                - /etc/conjure/phantom_subnets.toml:/opt/conjure/sysconfig/phantom_subnets.toml
                 - /dev/hugepages:/dev/hugepages
-                - /var/lib/tapdance/prod.privkey:/opt/conjure/keys/privkey
         depends_on:
                 - zbalance
                 - redis
@@ -52,11 +51,11 @@ services:
                 context: ../
                 dockerfile: ./docker/Dockerfile
                 target: application
-        environment:
-                - LOG_CLIENT_IP=true
+        env_file: /etc/conjure/conjure.conf
         volumes:
-                - /var/lib/tapdance/prod.privkey:/opt/conjure/sysconfig/privkey
-                - ./phantom_subnets.toml:/opt/conjure/sysconfig/phantom_subnets.toml
+                - /etc/conjure/app-config.toml:/opt/conjure/application/config.toml
+                - /etc/conjure/privkey:/opt/conjure/sysconfig/privkey
+                - /etc/conjure/phantom_subnets.toml:/opt/conjure/sysconfig/phantom_subnets.toml
         depends_on:
                 - zbalance
                 - detector

--- a/docker/start_zbalance_ipc.sh
+++ b/docker/start_zbalance_ipc.sh
@@ -29,5 +29,5 @@ do
     fi
 done
 echo "Setting up with params: -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE}"
-/opt/conjure/PF_RING/userland/examples_zc/zbalance_ipc -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE}
+zbalance_ipc -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT},${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE}
 


### PR DESCRIPTION
Update build and run process to expect config files in specific locations. This forces environments to configure parameters that will be used locally. Also fixes an issue where `CJ_IFACE` string containing multiple iface names is treated as one iface by `zbalance-entrypoint.sh`.

* Station Config is stored in `/etc/conjure/...` which docker maps to volumes in appropriate locations for each service (i.e `/etc/conjure/conjure.conf -> /opt/conjure/sysconfig/conjure.conf`). 
* `CJ_IFACE` (set in `/etc/conjure/conjure.conf`) can support multiple ifaces (i.e. `CJ_IFACE=enp5s0f0,enp5s0f1,...`).
  * `zbalance-entrypoint.sh` checks for ZC support in `/proc/net/pf_ring/dev/${iface}/info` for each individually.