### PR TITLE
Apply fixes for #114 liveness collisions

### DIFF
--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -90,8 +90,7 @@ type RegistrationManager struct {
 
 func NewRegistrationManager() *RegistrationManager {
 	logger := log.New(os.Stdout, "[REG] ", log.Ldate|log.Lmicroseconds)
-	var ult *lt.UncachedLivenessTester
-	ult = new(lt.UncachedLivenessTester)
+	var ult *lt.UncachedLivenessTester = new(lt.UncachedLivenessTester)
 	p, err := NewPhantomIPSelector()
 	if err != nil {
 		// fmt.Errorf("failed to create the PhantomIPSelector object: %v", err)

--- a/application/main.go
+++ b/application/main.go
@@ -250,7 +250,7 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 					liveness, response := regManager.PhantomIsLive(reg.DarkDecoy.String(), 443)
 
 					if liveness {
-						logger.Printf("Dropping registration %v -- live phantom: %v\n", reg.IDString(), response)
+						logger.Printf("Dropping registration %v -- live phantom (%s): %v\n", reg.IDString(), reg.DarkDecoy, response)
 						if response.Error() == lt.CACHED_PHANTOM_MSG {
 							cj.Stat().AddLivenessCached()
 						}

--- a/application/main.go
+++ b/application/main.go
@@ -402,6 +402,10 @@ func main() {
 	flag.Parse()
 
 	regManager := cj.NewRegistrationManager()
+	if regManager == nil {
+		fmt.Println("error occurred while setting up registration manager")
+		os.Exit(1)
+	}
 	logger = regManager.Logger
 
 	// Should we log client IP addresses

--- a/src/process_packet.rs
+++ b/src/process_packet.rs
@@ -395,8 +395,8 @@ mod tests {
             println!("{}", net);
         }
 
-        assert_eq!(true, nets.contains(&String::from("127.0.0.1")));
-        assert_eq!(true, nets.contains(&String::from("::1")));
-        assert_eq!(false, nets.contains(&String::from("127.0.0.2")))
+        assert!(nets.contains(&String::from("127.0.0.1")));
+        assert!(nets.contains(&String::from("::1")));
+        assert!(!nets.contains(&String::from("127.0.0.2")))
     }
 }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -153,16 +153,9 @@ impl fmt::Display for SessionDetails {
                 true => write!(
                     f,
                     "{} -> {} ({}ns)",
-                    self.client_ip.to_string(),
-                    self.phantom_ip.to_string(),
-                    self.timeout
+                    self.client_ip, self.phantom_ip, self.timeout
                 ),
-                false => write!(
-                    f,
-                    "_ -> {} ({}ns)",
-                    self.phantom_ip.to_string(),
-                    self.timeout
-                ),
+                false => write!(f, "_ -> {} ({}ns)", self.phantom_ip, self.timeout),
             }
         }
     }


### PR DESCRIPTION
This fix attempts to address two contributing factors to a relatively
large number of live phantoms seen in a multi-station deployment.
* refactor, simplify, and add test for detector filter list checks in detector
* add EnableV{4,6} check before continuing with a liveness scan for IPv{4,6}

Address #114 