### PR TITLE
Fix clippy lint warnings for rust 1.58

### DIFF
--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -153,16 +153,9 @@ impl fmt::Display for SessionDetails {
                 true => write!(
                     f,
                     "{} -> {} ({}ns)",
-                    self.client_ip.to_string(),
-                    self.phantom_ip.to_string(),
-                    self.timeout
+                    self.client_ip, self.phantom_ip, self.timeout
                 ),
-                false => write!(
-                    f,
-                    "_ -> {} ({}ns)",
-                    self.phantom_ip.to_string(),
-                    self.timeout
-                ),
+                false => write!(f, "_ -> {} ({}ns)", self.phantom_ip, self.timeout),
             }
         }
     }


### PR DESCRIPTION
The cargo clippy linter has added a new lint checking for the use of `to_string()` where the `Display` trait is already implemented allowing for simpler code. This is throwing a warning in a few places in `src/sessions.rs` causing the lint GH action to fail. 

This PR fixes those small warnings, allowing the GH action to pass for the latest version of clippy.