### PR TITLE
Bug fixes in ClientConf API delivery via Bidirectional Registrar

### DIFF
--- a/registration-api/api_test.go
+++ b/registration-api/api_test.go
@@ -519,3 +519,16 @@ func TestBidirectionalAPIClientConf(t *testing.T) {
 		t.Log("server client conf returned in registration response")
 	}
 }
+
+func TestAPIParseClientConf(t *testing.T) {
+	var s server
+	s.logger = log.New(os.Stdout, "[TESTAPI] ", log.Ldate|log.Lmicroseconds)
+	s.ClientConfPath = "./test/ClientConf"
+
+	cc, err := parseClientConf(s.ClientConfPath)
+	require.Nil(t, err)
+	s.latestClientConf = cc
+
+	require.NotNil(t, s.latestClientConf)
+	require.Equal(t, uint32(1153), s.latestClientConf.GetGeneration())
+}

--- a/registration-api/main.go
+++ b/registration-api/main.go
@@ -183,10 +183,10 @@ func (s *server) registerBidirectional(w http.ResponseWriter, r *http.Request) {
 	regResp := &pb.RegistrationResponse{}
 
 	// Check server's client config -- add server's ClientConf if client is outdated
-	serverClientConf := s.compareClientConfGen(*payload.RegistrationPayload.DecoyListGeneration)
+	serverClientConf := s.compareClientConfGen(payload.GetRegistrationPayload().GetDecoyListGeneration())
 	if serverClientConf != nil {
-		s.logger.Printf("Sending server client config in registration resp due to server gen %d and client gen %d\n",
-			*serverClientConf.Generation, *payload.RegistrationPayload.DecoyListGeneration)
+		// s.logger.Printf("Providing updated clientconf in reg resp %d -> %d\n",
+		// serverClientConf.GetGeneration(), payload.GetRegistrationPayload().GetDecoyListGeneration())
 
 		// Save the client config from server to return to client
 		regResp.ClientConf = serverClientConf
@@ -305,11 +305,11 @@ func parseClientConf(path string) (*pb.ClientConf, error) {
 func (s *server) compareClientConfGen(genNum uint32) *pb.ClientConf {
 	// Check that server has a currnet (latest) client config
 	if s.latestClientConf == nil {
-		s.logger.Println("Server latest ClientConf is nil")
+		// s.logger.Println("Server latest ClientConf is nil")
 		return nil
 	}
 
-	s.logger.Printf("client: %d, stored: %d\n", genNum, s.latestClientConf.GetGeneration())
+	// s.logger.Printf("client: %d, stored: %d\n", genNum, s.latestClientConf.GetGeneration())
 	// Check if generation number param is greater than server's client config
 	if genNum > s.latestClientConf.GetGeneration() {
 		return nil
@@ -398,9 +398,11 @@ func main() {
 	}
 
 	// Set latest client config based on saved file path
-	s.latestClientConf, err = parseClientConf(s.ClientConfPath)
+	cc, err := parseClientConf(s.ClientConfPath)
 	if err != nil {
 		s.logger.Printf("failed to parse the latest ClientConf based on path file: %v\n", err)
+	} else {
+		s.latestClientConf = cc
 	}
 
 	// Should we log client IP addresses


### PR DESCRIPTION
* remove potential nil pointer derefence in protobuf struct traversal
* remove non-specific debug log lines
* Add test for `parseClientConf()`