### PR TITLE
Log Misbehaving Client IPs

### DIFF
--- a/application/lib/config.go
+++ b/application/lib/config.go
@@ -2,10 +2,11 @@ package lib
 
 import (
 	"fmt"
-	"github.com/BurntSushi/toml"
 	"net"
 	"os"
 	"regexp"
+
+	"github.com/BurntSushi/toml"
 )
 
 // Config - Station golang configuration struct
@@ -85,6 +86,10 @@ func (c *Config) IsBlocklisted(urlStr string) bool {
 	}
 
 	if addr := net.ParseIP(host); addr != nil {
+		if !addr.IsGlobalUnicast() {
+			// No anycast / private / loopback allowed.
+			return true
+		}
 		for _, net := range c.covertBlocklistSubnets {
 			if net.Contains(addr) {
 				// blocked by IP address

--- a/application/lib/config_test.go
+++ b/application/lib/config_test.go
@@ -28,7 +28,6 @@ func TestConjureLibConfigBlocklists(t *testing.T) {
 	conf := &Config{
 		CovertBlocklistSubnets: []string{
 			"192.0.0.1/16",
-			"::1/128",
 		},
 		CovertBlocklistDomains: []string{
 			".*blocked\\.com$",
@@ -43,7 +42,6 @@ func TestConjureLibConfigBlocklists(t *testing.T) {
 	goodURLs := []string{
 		"[::2]:443",
 		"blocked2.com:443",
-		"127.0.0.1:443",
 		"example.com:443",
 		"192.255.0.22:domain",
 
@@ -59,6 +57,7 @@ func TestConjureLibConfigBlocklists(t *testing.T) {
 		"abc.blocked.com:443",
 		"blocked1.com:443",
 		"192.0.2.1:http",
+		"127.0.0.1:443",
 		"localhost:443",
 	}
 

--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -401,6 +401,13 @@ func (reg *DecoyRegistration) PreScanned() bool {
 	return reg.Flags.GetPrescanned()
 }
 
+// GetRegistrationAddress returns the address that was used to create this
+// registration. This should almost never be used - it exists to get the address
+// for debugging and for logging misbehaving client IPs.
+func (reg *DecoyRegistration) GetRegistrationAddress() string {
+	return reg.registrationAddr.String()
+}
+
 type DecoyTimeout struct {
 	decoy            string
 	identifier       string

--- a/application/main.go
+++ b/application/main.go
@@ -199,7 +199,8 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 		}
 
 		go func() {
-			// Handle multiple as receive_zmq_messages returns separate registrations for v4 and v6
+			// Handle multiple as receive_zmq_messages returns separate
+			// registrations for v4 and v6
 			for _, reg := range newRegs {
 				if reg == nil {
 					continue
@@ -210,7 +211,8 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 					logger.Printf("Duplicate registration: %v %s\n", reg.IDString(), reg.RegistrationSource)
 					cj.Stat().AddDupReg()
 
-					// Track the received registration, if it is already tracked it will just update the record
+					// Track the received registration, if it is already tracked
+					// it will just update the record
 					err := regManager.TrackRegistration(reg)
 					if err != nil {
 						logger.Println("error tracking registration: ", err)
@@ -229,9 +231,12 @@ func get_zmq_updates(connectAddr string, regManager *cj.RegistrationManager, con
 					cj.Stat().AddErrReg()
 				}
 
-				// If registration is trying to connect to a dark decoy that is blocklisted continue
+				// If registration is trying to connect to a dark decoy that is
+				// blocklisted continue
 				if reg.Covert == "" || conf.IsBlocklisted(reg.Covert) {
-					logger.Printf("Dropping reg, malformed or blocklisted covert: %v, %s, %v", reg.IDString(), reg.Covert, err)
+					// We log client IPs for clients attempting to connect to
+					// blocklisted covert addresses.
+					logger.Printf("Dropping reg, malformed or blocklisted covert: %v, %s -> %s", reg.IDString(), reg.GetRegistrationAddress(), reg.Covert)
 					cj.Stat().AddErrReg()
 					continue
 				}


### PR DESCRIPTION
Clients that register using covert addresses that are dissallowed at a particular station will have their registration ignored and their IP logged. This allows us to keep an eye on clients who are attempting to abuse the station. 

- [x] add global unicast check
- [x] Log registering IP when covert is blocklisted 