### PR TITLE
Correct path to start_zbalance_ipc.sh script

### DIFF
--- a/sysconfig/zbalance.service
+++ b/sysconfig/zbalance.service
@@ -14,7 +14,7 @@ EnvironmentFile=/opt/conjure/sysconfig/conjure.conf
 # makes if binary doesn't exist
 #ExecStartPre=/usr/bin/make zbalance
 
-ExecStart=/bin/bash /opt/conjure/start_zbalance_ipc.sh
+ExecStart=/bin/bash /opt/conjure/sysconfig/start_zbalance_ipc.sh
 
 # on stop processes will get SIGTERM, and after 10 secs - SIGKILL (default 90)
 TimeoutStopSec=10


### PR DESCRIPTION
I'm going through setting up a development environment and found an inconsistency in the zbalance service file. The service loads correctly when the path to `start_zbalance_ipc.sh` is changed to reflect it's relative location in the conjure  repository.