### PR TITLE
updating rust deps and repairing CI with deps

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -54,6 +54,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install protobuf-compiler software-properties-common -y -q
+          sudo apt-get install libzmq3-dev libssl-dev pkg-config libgmp3-dev -y -
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,11 @@ lazycell = "^0.5"
 libc = "~0.2"
 aes-gcm = "0.8.0"
 time = "0.1.*"
-pnet = "0.26.0"
+pnet = "0.31.0"
 arrayref = "0.3.2"
 log = "0.3.6"
 rand = "0.4.2"
 errno = "0.2.3"
-radix = { git = "https://github.com/refraction-networking/radix" }
 tuntap = { git = "https://github.com/ewust/tuntap.rs" }
 ipnetwork = "^0.14.0"
 protobuf = "2.20.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ extern crate rand;
 extern crate time;
 
 extern crate protobuf;
-extern crate radix; // https://github.com/refraction-networking/radix
 extern crate redis;
 extern crate serde;
 extern crate serde_derive;


### PR DESCRIPTION
* Update rust `pnet` dependency to move past a release with potential vulnerabilities.
* Update CI to install dependencies before golang-ci lint job (fixing broken CI job) 
* Remove now unused rust crate