### PR TITLE
Fix unconditional Return in obfs4 transport

### DIFF
--- a/application/transports/wrapping/obfs4/obfs4_test.go
+++ b/application/transports/wrapping/obfs4/obfs4_test.go
@@ -98,6 +98,10 @@ func TestSuccessfulWrap(t *testing.T) {
 	}
 }
 
+func TestSuccessfulWrapMulti(t *testing.T) {
+	t.Fatal("not yet implemented")
+}
+
 func TestUnsuccessfulWrap(t *testing.T) {
 	var transport Transport
 	var err error


### PR DESCRIPTION
first pass on fixing unconditional return - move checks on proper data length earlier in the function and continue through loop when the MAC mark that we are looking for is not found.

closes #128 