### PR TITLE
bidirectional api only include clientconf for gen less than current

### DIFF
--- a/registration-api/api_test.go
+++ b/registration-api/api_test.go
@@ -535,3 +535,30 @@ func TestAPIParseClientConf(t *testing.T) {
 	require.NotNil(t, s.latestClientConf)
 	require.Equal(t, uint32(1153), s.latestClientConf.GetGeneration())
 }
+
+func TestCompareCCGen(t *testing.T) {
+	s := server{
+		logger: logger,
+	}
+	s.logClientIP = true
+
+	s.config.ClientConfPath = "./test/ClientConf"
+
+	var err error
+	s.latestClientConf, err = parseClientConf(s.ClientConfPath)
+	if err != nil || s.latestClientConf == nil {
+		t.Fatalf("failed to parse test config")
+	}
+
+	// should include update for generation numbers less than server current
+	cc := s.compareClientConfGen(1152)
+	require.NotNil(t, cc)
+
+	// should NOT include update for generation numbers equal to server current
+	cc = s.compareClientConfGen(1153)
+	require.Nil(t, cc)
+
+	// should NOT include update for generation numbers greater than server current
+	cc = s.compareClientConfGen(1154)
+	require.Nil(t, cc)
+}

--- a/registration-api/main.go
+++ b/registration-api/main.go
@@ -319,7 +319,7 @@ func (s *server) compareClientConfGen(genNum uint32) *pb.ClientConf {
 
 	// s.logger.Printf("client: %d, stored: %d\n", genNum, s.latestClientConf.GetGeneration())
 	// Check if generation number param is greater than server's client config
-	if genNum > s.latestClientConf.GetGeneration() {
+	if genNum >= s.latestClientConf.GetGeneration() {
 		return nil
 	}
 


### PR DESCRIPTION
The bidirectional API is supposed to include an updated clientconfig if available, however the check currently includes the clientconf for connections that have the same generation number, using many more bytes than required for most registrations. 

This PR fixes this by changing the generation number check to ensure that equal generation numbers are not served the latest clientconfig (which they already have). 