### PR TITLE
bug fixes for obfs4 only. test will fail due to #133

### DIFF
--- a/application/lib/test/phantom_subnets_min.toml
+++ b/application/lib/test/phantom_subnets_min.toml
@@ -1,0 +1,12 @@
+
+# USED BY:
+# * lib/phantom_selector_test.go
+# * transports/wrapping/obfs4/obfs4_test.go
+#
+# Do not change without consulting those files and ensuring tests still pass.
+[Networks]
+	[Networks.1]
+        Generation = 1
+        [[Networks.1.WeightedSubnets]]
+            Weight = 1
+            Subnets = ["192.122.190.0/32", "2001:48a8:687f:1::/128"]

--- a/application/transports/wrapping/internal/tests/tests.go
+++ b/application/transports/wrapping/internal/tests/tests.go
@@ -18,8 +18,14 @@ type Transport struct {
 
 var SharedSecret = []byte(`6a328b8ec2024dd92dd64332164cc0425ddbde40cb7b81e055bf7b099096d068`)
 
+// SetupPhantomConnections registers one session with the provided transport and
+// registration manager using a pre-determined kay and phantom subnet file.
 func SetupPhantomConnections(manager *dd.RegistrationManager, transport pb.TransportType) (clientToPhantom net.Conn, serverFromPhantom net.Conn, reg *dd.DecoyRegistration) {
 	testSubnetPath := os.Getenv("GOPATH") + "/src/github.com/refraction-networking/conjure/application/lib/test/phantom_subnets.toml"
+	return SetupPhantomConnectionsSecret(manager, transport, SharedSecret, testSubnetPath)
+}
+
+func SetupPhantomConnectionsSecret(manager *dd.RegistrationManager, transport pb.TransportType, sharedSecret []byte, testSubnetPath string) (clientToPhantom net.Conn, serverFromPhantom net.Conn, reg *dd.DecoyRegistration) {
 	os.Setenv("PHANTOM_SUBNET_LOCATION", testSubnetPath)
 
 	phantom := bufconn.Listen(65535)
@@ -44,7 +50,7 @@ func SetupPhantomConnections(manager *dd.RegistrationManager, transport pb.Trans
 
 	wg.Wait()
 
-	keys, err := dd.GenSharedKeys(SharedSecret)
+	keys, err := dd.GenSharedKeys(sharedSecret)
 	if err != nil {
 		log.Fatalln("failed to generate shared keys:", err)
 	}

--- a/application/transports/wrapping/obfs4/obfs4_test.go
+++ b/application/transports/wrapping/obfs4/obfs4_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	dd "github.com/refraction-networking/conjure/application/lib"
 	"github.com/refraction-networking/conjure/application/transports"
 	"github.com/refraction-networking/conjure/application/transports/wrapping/internal/tests"
 	pb "github.com/refraction-networking/gotapdance/protobuf"
@@ -20,14 +21,14 @@ import (
 	"gitlab.com/yawning/obfs4.git/transports/obfs4"
 )
 
-func wrapConnection(conn net.Conn, nodeID, publicKey string, wrapped chan (net.Conn)) {
+func wrapConnection(conn net.Conn, nodeID, publicKey string, wrapped chan (net.Conn), stateDir string) {
 	args := pt.Args{}
 	args.Add("node-id", nodeID)
 	args.Add("public-key", publicKey)
 	args.Add("iat-mode", "1")
 
 	t := obfs4.Transport{}
-	c, err := t.ClientFactory("")
+	c, err := t.ClientFactory(stateDir)
 	if err != nil {
 		log.Fatalln("failed to set up client factory:", err)
 	}
@@ -57,7 +58,83 @@ func TestSuccessfulWrap(t *testing.T) {
 	defer sfp.Close()
 
 	wrappedc2p := make(chan net.Conn)
-	go wrapConnection(c2p, reg.Keys.Obfs4Keys.NodeID.Hex(), reg.Keys.Obfs4Keys.PublicKey.Hex(), wrappedc2p)
+	stateDir := t.TempDir()
+	go wrapConnection(c2p, reg.Keys.Obfs4Keys.NodeID.Hex(), reg.Keys.Obfs4Keys.PublicKey.Hex(), wrappedc2p, stateDir)
+
+	var buf [4096]byte
+	var buffer bytes.Buffer
+	var wrappedsfp net.Conn
+	var err error
+	for {
+		n, _ := sfp.Read(buf[:])
+		buffer.Write(buf[:n])
+
+		_, wrappedsfp, err = transport.WrapConnection(&buffer, sfp, reg.DarkDecoy, manager)
+		if errors.Is(err, transports.ErrTryAgain) {
+			continue
+		} else if err != nil {
+			t.Fatalf("expected nil or ErrTryAgain, got %v", err)
+		}
+
+		break
+	}
+
+	select {
+	case c2p = <-wrappedc2p:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for wrapped client connection")
+	}
+
+	message := []byte(`test message!`)
+	_, err = c2p.Write(message)
+	require.Nil(t, err)
+
+	received := make([]byte, len(message))
+	_, err = io.ReadFull(wrappedsfp, received)
+	if err != nil {
+		t.Fatalf("failed reading from connection: %v", err)
+	}
+
+	if !bytes.Equal(message, received) {
+		t.Fatalf("expected %v, got %v", message, received)
+	}
+}
+
+// TestSuccessfulWrapMulti is designed to ensure that the obfs4 implementation
+// of WrapConnection works when multiple registrations might share the same
+// phantom IP address. This requires mapping multiple registrations to the same
+// phantom before calling WrapConnection on one of them. This is done using a
+// subnet file that only has a an /32 allocation meaning all registrations by
+// default map to the same phantom address (for n=5 registrations). We wrap the
+// last connection.
+func TestSuccessfulWrapMulti(t *testing.T) {
+	testSubnetPath := os.Getenv("GOPATH") + "/src/github.com/refraction-networking/conjure/application/lib/test/phantom_subnets_min.toml"
+	os.Setenv("PHANTOM_SUBNET_LOCATION", testSubnetPath)
+
+	sharedSecrets := [][]byte{
+		[]byte(`b07c17169ac6c4ec77de4b795e939e3994dc708be1afb6bcd5e646941cf97f35`),
+		[]byte(`3143952b9355b6187ddc6104eb9ea85fca52ba5f8d88a93f73910f860b133217`),
+		[]byte(`62a807d9f89673960564185e893530216ef889545d9c039f9b02d8ccd36c093d`),
+		[]byte(`d078a5084786cfd51094e6c27718451e1260285068b6dbc7009c06de38d49711`),
+		tests.SharedSecret,
+	}
+
+	var transport Transport
+	manager := tests.SetupRegistrationManager(tests.Transport{Index: pb.TransportType_Obfs4, Transport: transport})
+	var c2p, sfp net.Conn
+	var reg *dd.DecoyRegistration
+
+	// register 5 sessions guaranteeing collisions on phantom IP addresses
+	for _, secret := range sharedSecrets {
+		c2p, sfp, reg = tests.SetupPhantomConnectionsSecret(manager, pb.TransportType_Obfs4, secret, testSubnetPath)
+	}
+
+	defer c2p.Close()
+	defer sfp.Close()
+
+	wrappedc2p := make(chan net.Conn)
+	stateDir := t.TempDir()
+	go wrapConnection(c2p, reg.Keys.Obfs4Keys.NodeID.Hex(), reg.Keys.Obfs4Keys.PublicKey.Hex(), wrappedc2p, stateDir)
 
 	var buf [4096]byte
 	var buffer bytes.Buffer


### PR DESCRIPTION
Fix for unconditional return in obfs4 WrapConnection - move checks on proper data length earlier in the function and continue through loop when the MAC mark that we are looking for is not found.

The fix(es) applied in this PR relates to #132 as we add a temporary fix that creates an [ioutil.tempdir](https://pkg.go.dev/io/ioutil#TempDir) for each obfs4 session ensuring separation of state. However this is probably not a good long-term fix as file descriptor limitations might cause issues, also we probably don't need any of the files to begin with.

closes #128 
relates to #132

### Changes

**obfs4**
* move mark len check proper locations 
  * too short check up front
  * not found, but not past max at end for retry
* mark not found w/ one reg, continue to next instead of return
* use tempdir instead of current dir for obfs4 state

### Proof that the fixes works:
TestSuccessfulWrapMulti - checks that a connection can be established for an obfs4 session even when multiple obfs4 sessions map to the same phantom address. 
