### PR TITLE
Blocklist fix via DNS pinning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get install protobuf-compiler gcc curl git wget software-properties-common -y -q
           sudo apt-get install libzmq3-dev libssl-dev pkg-config libgmp3-dev -y -q
           sudo add-apt-repository universe
-          wget https://packages.ntop.org/apt-stable/20.04/all/apt-ntop-stable.deb
+          wget https://packages.ntop.org/apt-stable/22.04/all/apt-ntop-stable.deb
           sudo apt-get install ./apt-ntop-stable.deb
           sudo apt-get update
           sudo apt-get install pfring
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Build app
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: Build Station pieces
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -36,8 +36,8 @@ jobs:
           sudo apt-get install protobuf-compiler gcc curl git wget software-properties-common -y -q
           sudo apt-get install libzmq3-dev libssl-dev pkg-config libgmp3-dev -y -q
           sudo add-apt-repository universe
-          wget https://packages.ntop.org/apt-stable/18.04/all/apt-ntop-stable.deb
-          sudo apt-get install ./apt-ntop-stable.deb
+          wget https://packages.ntop.org/apt/20.04/all/apt-ntop.deb
+          sudo apt install ./apt-ntop.deb
           sudo apt-get update
           sudo apt-get install pfring
           echo "Apt dependencies installed"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: Build Station pieces
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get install protobuf-compiler gcc curl git wget software-properties-common -y -q
           sudo apt-get install libzmq3-dev libssl-dev pkg-config libgmp3-dev -y -q
           sudo add-apt-repository universe
-          wget https://packages.ntop.org/apt-stable/22.04/all/apt-ntop-stable.deb
+          wget https://packages.ntop.org/apt-stable/18.04/all/apt-ntop-stable.deb
           sudo apt-get install ./apt-ntop-stable.deb
           sudo apt-get update
           sudo apt-get install pfring

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,8 @@ jobs:
           sudo apt-get install protobuf-compiler gcc curl git wget software-properties-common -y -q
           sudo apt-get install libzmq3-dev libssl-dev pkg-config libgmp3-dev -y -q
           sudo add-apt-repository universe
-          wget https://packages.ntop.org/apt/20.04/all/apt-ntop.deb
-          sudo apt install ./apt-ntop.deb
+          wget https://packages.ntop.org/apt-stable/20.04/all/apt-ntop-stable.deb
+          sudo apt install ./apt-ntop-stable.deb
           sudo apt-get update
           sudo apt-get install pfring
           echo "Apt dependencies installed"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get install protobuf-compiler gcc curl git wget software-properties-common -y -q
           sudo apt-get install libzmq3-dev libssl-dev pkg-config libgmp3-dev -y -q
           sudo add-apt-repository universe
-          wget https://packages.ntop.org/apt-stable/18.04/all/apt-ntop-stable.deb
+          wget https://packages.ntop.org/apt-stable/20.04/all/apt-ntop-stable.deb
           sudo apt-get install ./apt-ntop-stable.deb
           sudo apt-get update
           sudo apt-get install pfring

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.16.x, 1.17.x, 1.18.x]
 
     runs-on: ubuntu-latest
     steps:
@@ -37,7 +37,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/go/src/github.com/refraction-networking/conjure
           export GOPATH="$GITHUB_WORKSPACE/go"
-          go test -v ./...
+          go test -v -race ./...
 
       - name: Build app
         run: |

--- a/application/config.toml
+++ b/application/config.toml
@@ -27,19 +27,20 @@ heartbeat_timeout = 1000
 # in the liveness module.
 cache_expiration_time = "2.0h"
 
-# Allow the station to opt out of either version of internet protocol to limit a 
+# Allow the station to opt out of either version of internet protocol to limit a
 # statio to handling one or the other. For example, v6 on small station deployment
-# with only v6 phantom subnet,  v4 only on station with no puvlic v6 address. 
+# with only v6 phantom subnet,  v4 only on station with no puvlic v6 address.
 enable_v4 = true
 enable_v6 = false
 
 # If a registration is received with a covert address in one of these subnets it will
 # be ignored and dropped. This is to prevent clients leveraging the outgoing
-# connections from the station to connect to sation infrastructure that would 
+# connections from the station to connect to sation infrastructure that would
 # be othewise firewalled.
+covert_blocklist_domains = ["localhost"]
 covert_blocklist_subnets = [
     "127.0.0.1/32",     # localhost ipv4
-    "10.0.0.0/8",       # reserved ipv4 
+    "10.0.0.0/8",       # reserved ipv4
     "172.16.0.0/12",    # reserved ipv4
     "192.168.0.0/16",   # reserved ipv4
     "fc00::/7 ",        # private network ipv6
@@ -47,9 +48,14 @@ covert_blocklist_subnets = [
     "::1/128",           # localhost ipv6
 ]
 
-covert_blocklist_domains = [
-    "localhost",
-]
+# Automatically add all addresses and subnets associated with local devices to
+# the blocklist.
+covert_blocklist_public_addrs = false
+
+# Override the blocklist providing a more restrictive allowlist. Any addresses
+# not explicitly included in an allowlisted subnet will be considered
+# blocklisted and the registration will be dropped.
+covert_allowlist_subnets = []
 
 # If a registration is received and the phantom address is in one of these
 # subnets the registration will be dropped. This allows us to exclude subnets to

--- a/application/lib/config.go
+++ b/application/lib/config.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"regexp"
+	"strconv"
 
 	"github.com/BurntSushi/toml"
 )
@@ -98,6 +99,11 @@ func (c *Config) ParseOrResolveBlocklisted(provided string) string {
 		return ""
 	}
 	if c.isBlocklistedCovertDomain(host) {
+		return ""
+	}
+
+	_, err = strconv.ParseUint(port, 10, 16)
+	if err != nil {
 		return ""
 	}
 

--- a/application/lib/config_test.go
+++ b/application/lib/config_test.go
@@ -45,6 +45,7 @@ func TestConjureLibConfigResolveBlocklisted(t *testing.T) {
 		"128.0.2.1:25":     []string{"128.0.2.1:25"},
 		"[2001:db8::1]:80": []string{"[2001:db8::1]:80"},
 		"example.com:1234": []string{"93.184.216.34:1234", "[2606:2800:220:1:248:1893:25c8:1946]:1234"},
+		"[::2]:443":        []string{"[::2]:443"},
 	}
 
 	for input, expected := range goodTestCases {
@@ -58,6 +59,9 @@ func TestConjureLibConfigResolveBlocklisted(t *testing.T) {
 		"10.",
 		"::1::1",
 		".com:443",
+		"192.255.0.22:domain",
+		"192.255.0.22:100000",
+		"http://example.com",
 	}
 
 	for _, input := range malformedTestCases {

--- a/application/lib/config_test.go
+++ b/application/lib/config_test.go
@@ -4,6 +4,8 @@ import (
 	"net"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestConjureLibParseConfig(t *testing.T) {
@@ -23,11 +25,13 @@ func TestConjureLibParseConfig(t *testing.T) {
 	}
 }
 
-func TestConjureLibConfigBlocklists(t *testing.T) {
+func TestConjureLibConfigResolveBlocklisted(t *testing.T) {
 
 	conf := &Config{
 		CovertBlocklistSubnets: []string{
 			"192.0.0.1/16",
+			"127.0.0.1/32",
+			"::1/128",
 		},
 		CovertBlocklistDomains: []string{
 			".*blocked\\.com$",
@@ -37,21 +41,31 @@ func TestConjureLibConfigBlocklists(t *testing.T) {
 	}
 
 	conf.parseBlocklists()
-
-	// Addresses that pass Blocklisted check
-	goodURLs := []string{
-		"[::2]:443",
-		"blocked2.com:443",
-		"example.com:443",
-		"192.255.0.22:domain",
-
-		// These URLs will pass Blocklisted check, but fail at Dial("tcp", addr)
-		"https://127.0.0.1",
-		"https://example.com",
+	goodTestCases := map[string][]string{
+		"128.0.2.1:25":     []string{"128.0.2.1:25"},
+		"[2001:db8::1]:80": []string{"[2001:db8::1]:80"},
+		"example.com:1234": []string{"93.184.216.34:1234", "[2606:2800:220:1:248:1893:25c8:1946]:1234"},
 	}
 
-	// Test Blocking
-	blockedURLs := []string{
+	for input, expected := range goodTestCases {
+		output := conf.ParseOrResolveBlocklisted(input)
+		require.Contains(t, expected, output)
+	}
+
+	malformedTestCases := []string{
+		"0.42.42.42",
+		"192.0.2.1",
+		"10.",
+		"::1::1",
+		".com:443",
+	}
+
+	for _, input := range malformedTestCases {
+		output := conf.ParseOrResolveBlocklisted(input)
+		require.Equal(t, "", output)
+	}
+
+	blocklistedTestCases := []string{
 		"[::1]:443",
 		"blocked.com:443",
 		"abc.blocked.com:443",
@@ -61,32 +75,9 @@ func TestConjureLibConfigBlocklists(t *testing.T) {
 		"localhost:443",
 	}
 
-	// These urls will fail Blocklisted check (and also fail Dial("tcp", addr)).
-	badURLs := []string{
-		"https://::1",
-		"https://[::1]:443",
-		"127.0.0.1",
-		"https://127.0.0.1:443",
-		"example.com",
-		"",
-	}
-
-	for _, s := range goodURLs {
-		if conf.IsBlocklisted(s) {
-			t.Fatalf("Blocklist error - %s should not be blocked", s)
-		}
-	}
-
-	for _, s := range blockedURLs {
-		if !conf.IsBlocklisted(s) {
-			t.Fatalf("Blocklist error - %s should be blocked", s)
-		}
-	}
-
-	for _, s := range badURLs {
-		if !conf.IsBlocklisted(s) {
-			t.Fatalf("Blocklist error - %s should fail (malformed)", s)
-		}
+	for _, input := range blocklistedTestCases {
+		output := conf.ParseOrResolveBlocklisted(input)
+		require.Equal(t, "", output, "should be blocklisted")
 	}
 }
 

--- a/libtapdance/elligator2.c
+++ b/libtapdance/elligator2.c
@@ -148,13 +148,14 @@ size_t get_payload_from_tag(const unsigned char *station_privkey,
 }
 
 
-// Client calls this to get a random shared secret and public point,
-// given the station's public key.
+// Client calls this to get a random shared secret and public point, given the
+// station's public key. Disabled in conjure because unused - client 25519 happens
+// in golang.
 void get_encoded_point_and_secret(const unsigned char *station_public,
                                   unsigned char *shared_secret_out,
                                   unsigned char *encoded_point_out)
 {
-
+    /*
     // First, generate an ECC point
     unsigned char base_point[32] = {9};
     unsigned char client_secret[32];        // e
@@ -192,31 +193,32 @@ void get_encoded_point_and_secret(const unsigned char *station_public,
 
     memset(client_secret, 0, sizeof(client_secret));
     memset(client_public, 0, sizeof(client_public));
-
+    */ 
     return;
 }
 
-// tag_out length must be at least 32 + payload_len + 16 to be safe
-// For the client; given a payload and a station public key, provides
-// a tag (and returns its length). This tag is constructed by generating a
-// private_key, its associated public point, and a shared_secret with the station.
-// shared_secret is computed as SHA256(private_key*station_pubkey)
+// tag_out length must be at least 32 + payload_len + 16 to be safe For the
+// client; given a payload and a station public key, provides a tag (and returns
+// its length). This tag is constructed by generating a private_key, its
+// associated public point, and a shared_secret with the station. shared_secret
+// is computed as SHA256(private_key*station_pubkey)
 //
-// The tag is then:
-//   [      32 bytes            ]   [    payload_len + 16 bytes   ]
-// Elligator.encode(public_point) + AES_GCM(shared_secret[0:16], payload)
-//      (Note: IV provided to AES_GCM is shared_secret[16:32])
+// The tag is then: [      32 bytes            ]   [    payload_len + 16 bytes
+//   ] Elligator.encode(public_point) + AES_GCM(shared_secret[0:16], payload)
+//   (Note: IV provided to AES_GCM is shared_secret[16:32])
 //
-//  Note that there is no length or header that tells the station how large
-//  the payload. (It can't be in the clear; though we could do something like:
-//    AES_GCM(shared_secret[0:16], header) + AES_GCM(shared_secret[0:16], payload)
-//    with different IVs in each AES_GCM invocation. This would add
-//    len(header)+16 bytes overhead.)
+//  Note that there is no length or header that tells the station how large the
+//  payload. (It can't be in the clear; though we could do something like:
+//  AES_GCM(shared_secret[0:16], header) + AES_GCM(shared_secret[0:16], payload)
+//  with different IVs in each AES_GCM invocation. This would add len(header)+16
+//  bytes overhead.)
 //
+// Disabled in conjure because unused - tag creation happens in golang
 size_t get_tag_from_payload(const unsigned char *payload, size_t payload_len,
                             const unsigned char *station_pubkey,
                             unsigned char *tag_out)
 {
+    /*
     unsigned char shared_secret[32];
     size_t len = 0;
 
@@ -278,8 +280,8 @@ size_t get_tag_from_payload(const unsigned char *payload, size_t payload_len,
     }
     len += 16;
     EVP_CIPHER_CTX_free(ctx);
-
-    return len;
+    */
+    return 0;
 }
 
 int elligator_init = 0;


### PR DESCRIPTION
This PR addresses an SSRF issue by resolving all covert domains before applying the blocklist filtering.  Resolved addresses are  then DNS pinned to registrations to prevent DNS rebinding attacks. 

Along with this fix we comment client code for generating tag information that is unused in conjure (client ed25519 tag generation is done in golang). In general we consider memory exfiltration attacks against clients out of scope. 