### PR TITLE
Fix phantom selection algorithm

### DIFF
--- a/application/lib/phantom_selector.go
+++ b/application/lib/phantom_selector.go
@@ -20,9 +20,10 @@ const (
 	phantomHkdfMinVersion         uint = 2
 )
 
-// getSubnetsVarint - return EITHER all subnet strings as one composite array if we are
-//		selecting unweighted, or return the array associated with the (seed) selected
-//		array of subnet strings based on the associated weights
+// getSubnetsVarint - return EITHER all subnet strings as one composite array if
+// we are selecting unweighted, or return the array associated with the (seed)
+// selected array of subnet strings based on the associated weights
+//
 // Used by Client version 0 and 1
 func (sc *SubnetConfig) getSubnetsVarint(seed []byte, weighted bool) []string {
 
@@ -58,6 +59,12 @@ func (sc *SubnetConfig) getSubnetsVarint(seed []byte, weighted bool) []string {
 	return out
 }
 
+// getSubnetsHkdf returns EITHER all subnet strings as one composite array if
+// we are selecting unweighted, or return the array associated with the (seed)
+// selected array of subnet strings based on the associated weights. Random
+// values are seeded using an hkdf function to prevent biases introduced by
+// math/rand and varint.
+//
 // Used by Client version 2+
 func (sc *SubnetConfig) getSubnetsHkdf(seed []byte, weighted bool) []string {
 
@@ -127,8 +134,8 @@ func (sc *SubnetConfig) getSubnetsHkdf(seed []byte, weighted bool) []string {
 	return out
 }
 
-// SubnetFilter - Filter IP subnets based on whatever to prevent specific subnets from
-//		inclusion in choice. See v4Only and v6Only for reference.
+// SubnetFilter - Filter IP subnets based on whatever to prevent specific
+// subnets from inclusion in choice. See v4Only and v6Only for reference.
 type SubnetFilter func([]*net.IPNet) ([]*net.IPNet, error)
 
 // V4Only - a functor for transforming the subnet list to only include IPv4 subnets
@@ -182,8 +189,9 @@ func parseSubnets(phantomSubnets []string) ([]*net.IPNet, error) {
 	// return nil, fmt.Errorf("parseSubnets not implemented yet")
 }
 
-// NewPhantomIPSelector - create object currently populated with a static map of generation number
-//		to SubnetConfig, but this may be loaded dynamically in the future.
+// NewPhantomIPSelector - create object currently populated with a static map of
+// generation number to SubnetConfig, but this may be loaded dynamically in the
+// future.
 func NewPhantomIPSelector() (*PhantomIPSelector, error) {
 	return GetPhantomSubnetSelector()
 }
@@ -230,10 +238,10 @@ func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer ui
 	return selectPhantomImplHkdf(seed, genSubnets)
 }
 
-// selectPhantomImpl - select an ip address from the list of subnets associated
-// with the specified generation by constructing a set of start and end values
-// for the high and low values in each allocation. The random number is then
-// bound between the global min and max of that set. This ensures that
+// selectPhantomImplVarint - select an ip address from the list of subnets
+// associated with the specified generation by constructing a set of start and
+// end values for the high and low values in each allocation. The random number
+// is then bound between the global min and max of that set. This ensures that
 // addresses are chosen based on the number of addresses in the subnet.
 func selectPhantomImplVarint(seed []byte, subnets []*net.IPNet) (net.IP, error) {
 	type idNet struct {
@@ -301,8 +309,8 @@ func selectPhantomImplVarint(seed []byte, subnets []*net.IPNet) (net.IP, error) 
 	return result, nil
 }
 
-// selectV0 implements support for the legacy (buggy) client phantom address
-// selection algorithm.
+// selectPhantomImplV0 implements support for the legacy (buggy) client phantom
+// address selection algorithm.
 func selectPhantomImplV0(seed []byte, subnets []*net.IPNet) (net.IP, error) {
 
 	addressTotal := big.NewInt(0)
@@ -363,10 +371,11 @@ func selectPhantomImplV0(seed []byte, subnets []*net.IPNet) (net.IP, error) {
 }
 
 // SelectAddrFromSubnet - given a seed and a CIDR block choose an address.
-// 		This is done by generating a seeded random bytes up to teh length of the
-//		full address then using the net mask to zero out any bytes that are
-//		already specified by the CIDR block. Tde masked random value is then
-//		added to the cidr block base giving the final randomly selected address.
+//
+// This is done by generating a seeded random bytes up to teh length of the full
+// address then using the net mask to zero out any bytes that are already
+// specified by the CIDR block. Tde masked random value is then added to the
+// cidr block base giving the final randomly selected address.
 func SelectAddrFromSubnet(seed []byte, net1 *net.IPNet) (net.IP, error) {
 	bits, addrLen := net1.Mask.Size()
 
@@ -405,8 +414,9 @@ func SelectAddrFromSubnet(seed []byte, net1 *net.IPNet) (net.IP, error) {
 	return net.IP(ipBigInt.Bytes()), nil
 }
 
-// Version 2: HKDF-based
 // SelectAddrFromSubnetOffset given a CIDR block and offset, return the net.IP
+//
+// Version 2: HKDF-based
 func SelectAddrFromSubnetOffset(net1 *net.IPNet, offset *big.Int) (net.IP, error) {
 	bits, addrLen := net1.Mask.Size()
 
@@ -431,10 +441,10 @@ func SelectAddrFromSubnetOffset(net1 *net.IPNet, offset *big.Int) (net.IP, error
 	return net.IP(ipBigInt.Bytes()), nil
 }
 
-// selectIPAddr selects an ip address from the list of subnets associated
-// with the specified generation by constructing a set of start and end values
-// for the high and low values in each allocation. The random number is then
-// bound between the global min and max of that set. This ensures that
+// selectPhantomImplHkdf selects an ip address from the list of subnets
+// associated with the specified generation by constructing a set of start and
+// end values for the high and low values in each allocation. The random number
+// is then bound between the global min and max of that set. This ensures that
 // addresses are chosen based on the number of addresses in the subnet.
 func selectPhantomImplHkdf(seed []byte, subnets []*net.IPNet) (net.IP, error) {
 	type idNet struct {
@@ -504,8 +514,9 @@ func selectPhantomImplHkdf(seed []byte, subnets []*net.IPNet) (net.IP, error) {
 	return result, nil
 }
 
-// GetSubnetsByGeneration - provide a generatio index. If the generation exists the associated
-//		subnetconfig is returned. If it is not defined the default subnets are returned.
+// GetSubnetsByGeneration - provide a generation index. If the generation exists
+// the associated SubnetConfig is returned. If it is not defined the default
+// subnets are returned.
 func (p *PhantomIPSelector) GetSubnetsByGeneration(generation uint) *SubnetConfig {
 	if subnets, ok := p.Networks[generation]; ok {
 		return subnets
@@ -516,7 +527,8 @@ func (p *PhantomIPSelector) GetSubnetsByGeneration(generation uint) *SubnetConfi
 }
 
 // AddGeneration - add a subnet config as a new new generation, if the requested
-//		generation index is taken then it uses (and returns) the next available number.
+// generation index is taken then it uses (and returns) the next available
+// number.
 func (p *PhantomIPSelector) AddGeneration(gen int, subnets *SubnetConfig) uint {
 
 	ugen := uint(gen)
@@ -553,7 +565,7 @@ func (p *PhantomIPSelector) RemoveGeneration(generation uint) bool {
 	return true
 }
 
-//UpdateGeneration - Update the subnet list associated with a specific generation
+// UpdateGeneration - Update the subnet list associated with a specific generation
 func (p *PhantomIPSelector) UpdateGeneration(generation uint, subnets *SubnetConfig) bool {
 	p.Networks[generation] = subnets
 	return true

--- a/application/lib/phantom_selector.go
+++ b/application/lib/phantom_selector.go
@@ -1,24 +1,30 @@
 package lib
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
-	"math/rand"
+	mrand "math/rand"
 	"net"
+	"sort"
 
 	wr "github.com/mroth/weightedrand"
+	"golang.org/x/crypto/hkdf"
 )
 
 const (
 	phantomSelectionMinGeneration uint = 1
+	phantomHkdfMinVersion         uint = 2
 )
 
-// getSubnets - return EITHER all subnet strings as one composite array if we are
+// getSubnetsVarint - return EITHER all subnet strings as one composite array if we are
 //		selecting unweighted, or return the array associated with the (seed) selected
 //		array of subnet strings based on the associated weights
-func (sc *SubnetConfig) getSubnets(seed []byte, weighted bool) []string {
+// Used by Client version 0 and 1
+func (sc *SubnetConfig) getSubnetsVarint(seed []byte, weighted bool) []string {
 
 	var out []string = []string{}
 
@@ -29,7 +35,7 @@ func (sc *SubnetConfig) getSubnets(seed []byte, weighted bool) []string {
 			fmt.Println("failed to seed random for weighted rand")
 			return nil
 		}
-		rand.Seed(seedInt)
+		mrand.Seed(seedInt)
 
 		choices := make([]wr.Choice, 0, len(sc.WeightedSubnets))
 		for _, cjSubnet := range sc.WeightedSubnets {
@@ -45,6 +51,75 @@ func (sc *SubnetConfig) getSubnets(seed []byte, weighted bool) []string {
 
 		// Use unweighted config for subnets, concat all into one array and return.
 		for _, cjSubnet := range sc.WeightedSubnets {
+			out = append(out, cjSubnet.Subnets...)
+		}
+	}
+
+	return out
+}
+
+// Used by Client version 2+
+func (sc *SubnetConfig) getSubnetsHkdf(seed []byte, weighted bool) []string {
+
+	type Choice struct {
+		Subnets []string
+		Weight  int64
+	}
+
+	var out []string = []string{}
+
+	if weighted {
+
+		weightedSubnets := sc.WeightedSubnets
+		if weightedSubnets == nil {
+			return []string{}
+		}
+
+		choices := make([]Choice, 0, len(weightedSubnets))
+
+		totWeight := int64(0)
+		for _, cjSubnet := range weightedSubnets {
+			weight := cjSubnet.Weight
+			subnets := cjSubnet.Subnets
+			if subnets == nil {
+				continue
+			}
+
+			totWeight += int64(weight)
+			choices = append(choices, Choice{Subnets: subnets, Weight: int64(weight)})
+		}
+
+		// Sort choices assending
+		sort.Slice(choices, func(i, j int) bool {
+			return choices[i].Weight < choices[j].Weight
+		})
+
+		// Naive method: get random int, subtract from weights until you are < 0
+		hkdfReader := hkdf.New(sha256.New, seed, nil, []byte("phantom-select-subnet"))
+		totWeightBig := big.NewInt(totWeight)
+		rndBig, err := rand.Int(hkdfReader, totWeightBig)
+		if err != nil {
+			return nil
+		}
+
+		// Decrement rnd by each weight until it's < 0
+		rnd := rndBig.Int64()
+		for _, choice := range choices {
+			rnd -= choice.Weight
+			if rnd < 0 {
+				return choice.Subnets
+			}
+		}
+
+	} else {
+
+		weightedSubnets := sc.WeightedSubnets
+		if weightedSubnets == nil {
+			return []string{}
+		}
+
+		// Use unweighted config for subnets, concat all into one array and return.
+		for _, cjSubnet := range weightedSubnets {
 			out = append(out, cjSubnet.Subnets...)
 		}
 	}
@@ -121,7 +196,14 @@ func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer ui
 		return nil, fmt.Errorf("generation number not recognized")
 	}
 
-	genSubnetStrings := genConfig.getSubnets(seed, true)
+	var genSubnetStrings []string
+	if clientLibVer < phantomHkdfMinVersion {
+		// Version 0 or 1
+		genSubnetStrings = genConfig.getSubnetsVarint(seed, true)
+	} else {
+		// Version 2
+		genSubnetStrings = genConfig.getSubnetsHkdf(seed, true)
+	}
 
 	genSubnets, err := parseSubnets(genSubnetStrings)
 	if err != nil {
@@ -137,10 +219,15 @@ func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer ui
 
 	// handle legacy clientLibVersions for selecting phantoms.
 	if clientLibVer < phantomSelectionMinGeneration {
+		// Version 0
 		return selectPhantomImplV0(seed, genSubnets)
+	} else if clientLibVer < phantomHkdfMinVersion {
+		// Version 1
+		return selectPhantomImplVarint(seed, genSubnets)
 	}
 
-	return selectPhantomImpl(seed, genSubnets)
+	// Version 2+
+	return selectPhantomImplHkdf(seed, genSubnets)
 }
 
 // selectPhantomImpl - select an ip address from the list of subnets associated
@@ -148,7 +235,7 @@ func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer ui
 // for the high and low values in each allocation. The random number is then
 // bound between the global min and max of that set. This ensures that
 // addresses are chosen based on the number of addresses in the subnet.
-func selectPhantomImpl(seed []byte, subnets []*net.IPNet) (net.IP, error) {
+func selectPhantomImplVarint(seed []byte, subnets []*net.IPNet) (net.IP, error) {
 	type idNet struct {
 		min, max big.Int
 		net      net.IPNet
@@ -295,9 +382,9 @@ func SelectAddrFromSubnet(seed []byte, net1 *net.IPNet) (net.IP, error) {
 		return nil, fmt.Errorf("failed to create seed ")
 	}
 
-	rand.Seed(seedInt)
+	mrand.Seed(seedInt)
 	randBytes := make([]byte, addrLen/8)
-	_, err := rand.Read(randBytes)
+	_, err := mrand.Read(randBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -316,6 +403,105 @@ func SelectAddrFromSubnet(seed []byte, net1 *net.IPNet) (net.IP, error) {
 	ipBigInt.Add(ipBigInt, randBigInt)
 
 	return net.IP(ipBigInt.Bytes()), nil
+}
+
+// Version 2: HKDF-based
+// SelectAddrFromSubnetOffset given a CIDR block and offset, return the net.IP
+func SelectAddrFromSubnetOffset(net1 *net.IPNet, offset *big.Int) (net.IP, error) {
+	bits, addrLen := net1.Mask.Size()
+
+	// Compute network size (e.g. an ipv4 /24 is 2^(32-24)
+	var netSize big.Int
+	netSize.Exp(big.NewInt(2), big.NewInt(int64(addrLen-bits)), nil)
+
+	// Check that offset is within this subnet
+	if netSize.Cmp(offset) <= 0 {
+		return nil, errors.New("Offset too big for subnet")
+	}
+
+	ipBigInt := &big.Int{}
+	if v4net := net1.IP.To4(); v4net != nil {
+		ipBigInt.SetBytes(net1.IP.To4())
+	} else if v6net := net1.IP.To16(); v6net != nil {
+		ipBigInt.SetBytes(net1.IP.To16())
+	}
+
+	ipBigInt.Add(ipBigInt, offset)
+
+	return net.IP(ipBigInt.Bytes()), nil
+}
+
+// selectIPAddr selects an ip address from the list of subnets associated
+// with the specified generation by constructing a set of start and end values
+// for the high and low values in each allocation. The random number is then
+// bound between the global min and max of that set. This ensures that
+// addresses are chosen based on the number of addresses in the subnet.
+func selectPhantomImplHkdf(seed []byte, subnets []*net.IPNet) (net.IP, error) {
+	type idNet struct {
+		min, max big.Int
+		net      net.IPNet
+	}
+	var idNets []idNet
+
+	// Compose a list of ID Nets with min, max and network associated and count
+	// the total number of available addresses.
+	addressTotal := big.NewInt(0)
+	for _, _net := range subnets {
+		netMaskOnes, _ := _net.Mask.Size()
+		if ipv4net := _net.IP.To4(); ipv4net != nil {
+			_idNet := idNet{}
+			_idNet.min.Set(addressTotal)
+			addressTotal.Add(addressTotal, big.NewInt(2).Exp(big.NewInt(2), big.NewInt(int64(32-netMaskOnes)), nil))
+			_idNet.max.Sub(addressTotal, big.NewInt(1))
+			_idNet.net = *_net
+			idNets = append(idNets, _idNet)
+		} else if ipv6net := _net.IP.To16(); ipv6net != nil {
+			_idNet := idNet{}
+			_idNet.min.Set(addressTotal)
+			addressTotal.Add(addressTotal, big.NewInt(2).Exp(big.NewInt(2), big.NewInt(int64(128-netMaskOnes)), nil))
+			_idNet.max.Sub(addressTotal, big.NewInt(1))
+			_idNet.net = *_net
+			idNets = append(idNets, _idNet)
+		} else {
+			return nil, fmt.Errorf("failed to parse %v", _net)
+		}
+	}
+
+	// If the total number of addresses is 0 something has gone wrong
+	if addressTotal.Cmp(big.NewInt(0)) <= 0 {
+		return nil, fmt.Errorf("no valid addresses specified")
+	}
+
+	// Pick a value using the seed in the range of between 0 and the total
+	// number of addresses.
+	hkdfReader := hkdf.New(sha256.New, seed, nil, []byte("phantom-addr-id"))
+	id, err := rand.Int(hkdfReader, addressTotal)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the network (ID net) that contains our random value and select a
+	// random address from that subnet.
+	// min >= id%total >= max
+	var result net.IP
+	for _, _idNet := range idNets {
+		// fmt.Printf("tot:%s, seed%%tot:%s     id cmp max: %d,  id cmp min: %d %s\n", addressTotal.String(), id, _idNet.max.Cmp(id), _idNet.min.Cmp(id), _idNet.net.String())
+		if _idNet.max.Cmp(id) >= 0 && _idNet.min.Cmp(id) <= 0 {
+
+			var offset big.Int
+			offset.Sub(id, &_idNet.min)
+			result, err = SelectAddrFromSubnetOffset(&_idNet.net, &offset)
+			if err != nil {
+				return nil, fmt.Errorf("failed to chose IP address: %v", err)
+			}
+		}
+	}
+
+	// We want to make it so this CANNOT happen
+	if result == nil {
+		return nil, errors.New("nil result should not be possible")
+	}
+	return result, nil
 }
 
 // GetSubnetsByGeneration - provide a generatio index. If the generation exists the associated

--- a/application/lib/phantom_selector_test.go
+++ b/application/lib/phantom_selector_test.go
@@ -160,7 +160,7 @@ func TestPhantomsSeededSelectionV4Min(t *testing.T) {
 	seed, err := hex.DecodeString("5a87133b68ea3468988a21659a12ed2ece07345c8c1a5b08459ffdea4218d12f")
 	require.Nil(t, err)
 
-	phantomAddr, err := selectPhantomImpl(seed, subnets)
+	phantomAddr, err := selectPhantomImplVarint(seed, subnets)
 	require.Nil(t, err)
 
 	possibleAddrs := []string{"192.122.190.0", "2001:48a8:687f:1::"}
@@ -192,7 +192,7 @@ func TestPhantomSeededSelectionFuzz(t *testing.T) {
 			require.Equal(t, n, 32)
 
 			// phantomAddr, err := phantomSelector.Select(seed, newGen, false)
-			phantomAddr, err := selectPhantomImpl(seed, subnets)
+			phantomAddr, err := selectPhantomImplVarint(seed, subnets)
 			require.Nil(t, err, "i=%d, j=%d, seed='%s'", i, j, hex.EncodeToString(seed))
 			require.NotNil(t, phantomAddr)
 		}

--- a/application/lib/phantom_selector_test.go
+++ b/application/lib/phantom_selector_test.go
@@ -334,6 +334,7 @@ func TestDuplicates(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to select adddress: %v -- %s -- %v", err, hex.EncodeToString(curSeed), i)
 		}
+		//fmt.Printf("%s %v\n", hex.EncodeToString(curSeed), addr)
 
 		if prev_i, ok := ipSet[addr.String()]; ok {
 			prevSeed := ExpandSeed(seed, salt, prev_i)


### PR DESCRIPTION
**Problem**
Our current (V1) phantom selection algorithm depends on `math/rand` and has a bug involving Varints: we attempt to parse the 256-bit secret as a Varint to get a 4-byte integer, which we seed `math/rand` with. Unfortunately, half of the secrets we would pass in would have a leading 0 bit, causing the Varint parsing to return only the single byte (in the range -64 to 63). As a result, half the time we will only select from a set of 128 phantom IPs.

An example test `TestDuplicates` is now in phantom_selector_test.go, and if one edits the ClientLibVersion to be 1, it will detect the problem. Notice the leading bit of both seeds are 0, and the byte is the same (0x30) between the two tests that demonstrate generating the same IPv6 address.

```
--- FAIL: TestDuplicates (0.00s)
    phantom_selector_test.go:341: Generated duplicate IP; biased random. Both seeds 25 and 12 generated 2002::ee94:8e44:13ce:4e81
        25: 30af851e2b8e4dd57db8830d5fc6f759bdc2c7a5a396f6641cc23604fa61c851
        12: 301f4d8eba57f250e9fc3fa8205b3703fb4a6edbe4941f2a8ff2bc01e05051a9
FAIL
exit status 1
FAIL	github.com/refraction-networking/conjure/application/lib	7.549s
```

**Solution**
Client version >= 2 switches to using an HKDF-based version, instead of `math/rand`. This changes the phantom selection algorithm in a breaking way, and so the station uses the provided clientLibVersion to determine whether to use the new HKDF selection or the legacy one(s). 

This PR should be merged and deployed before the corresponding client update (https://github.com/refraction-networking/gotapdance/pull/106)