### PR TITLE
Phantom reload

### DIFF
--- a/application/lib/test/phantom_subnets_update.toml
+++ b/application/lib/test/phantom_subnets_update.toml
@@ -1,0 +1,32 @@
+
+
+[Networks]
+	[Networks.1]
+        Generation = 1
+        [[Networks.1.WeightedSubnets]]
+            Weight = 9
+            Subnets = ["192.122.190.0/24", "2001:48a8:687f:1::/64"]
+
+    [Networks.2]
+        Generation = 2
+        [[Networks.2.WeightedSubnets]]
+            Weight = 1
+            Subnets = ["192.122.190.0/28", "2001:48a8:687f:1::/96"]
+
+    [Networks.957]
+        Generation = 957
+        [[Networks.957.WeightedSubnets]]
+            Weight = 9
+            Subnets = ["192.122.190.0/24", "2001:48a8:687f:1::/64"]
+        [[Networks.957.WeightedSubnets]]
+            Weight = 1
+            Subnets = ["141.219.0.0/16", "35.8.0.0/16"]
+
+    [Networks.1000]
+        Generation = 1000
+        [[Networks.1000.WeightedSubnets]]
+            Weight = 9
+            Subnets = ["192.168.10.0/24", "2001:1::/64"]
+        [[Networks.1000.WeightedSubnets]]
+            Weight = 1
+            Subnets = ["10.0.0.0/16"]

--- a/application/main.go
+++ b/application/main.go
@@ -107,14 +107,26 @@ func main() {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	for sig := range sigCh {
-		// Wait for SIGINT.
+		// Wait for close signal.
 		if sig != syscall.SIGHUP {
+			logger.Infof("received %s ... exiting\n", sig.String())
 			break
 		}
 
-		// regManager.ReloadConfig()
+		// Use SigHUP to indicate config reload
+		logger.Infoln("received SIGHUP ... reloading configs")
+
+		// parse toml station configuration. If parse fails, log and abort
+		// reload.
+		newConf, err := cj.ParseConfig()
+		if err != nil {
+			log.Errorf("failed to parse app config: %v", err)
+		} else {
+			regManager.OnReload(newConf.RegConfig)
+		}
 	}
 
 	cancel()
 	wg.Wait()
+	logger.Infof("shutdown complete")
 }


### PR DESCRIPTION
Use the SIGHUP signal to indicate to the station to re-parse and apply changes to the configs in production without a shutdown.