### PR TITLE
Adjust default ingest buffer channel capacity

### DIFF
--- a/application/lib/registration_ingest.go
+++ b/application/lib/registration_ingest.go
@@ -18,8 +18,10 @@ import (
 )
 
 const (
-	defaultWorkerCount  = 300
-	jobBufferMultiplier = 1
+	defaultWorkerCount = 300
+	// Job buffer 1/10th the number of workers to make sure it doesn't back up,
+	// invalidating registrations.
+	jobBufferDivisor = 10
 )
 
 // HandleRegUpdates is responsible for launching and managing registration
@@ -44,7 +46,7 @@ func (rm *RegistrationManager) HandleRegUpdates(ctx context.Context, regChan <-c
 	wg := new(sync.WaitGroup)
 
 	// Add a shallow buffer for incoming registrations
-	shallowBuffer := make(chan interface{}, jobBufferMultiplier*workers)
+	shallowBuffer := make(chan interface{}, workers/jobBufferDivisor)
 	defer close(shallowBuffer)
 
 	// Add to registration manager so that we cann access it for stats printing.


### PR DESCRIPTION
The default ingest buffer capacity should be small. Allowing registrations to queue for too long hurts the health of the station overall during and following a burst of registrations. It must be possible to handle any registrations that do make it into the buffer in a reasonable amount of time, otherwise the registrations should be dropped. 