### PR TITLE
Reload Handling for combined Reg Server

### DIFF
--- a/cmd/registration-server/main.go
+++ b/cmd/registration-server/main.go
@@ -118,7 +118,7 @@ func readKeyAndEncode(path string) (string, error) {
 // should allow us to dynamically reload when there is an update to the latest
 // client configuration or the phantom subnets that we select from.
 func loadConfig(configPath string) (*config, error) {
-	var conf *config
+	conf := &config{}
 	_, err := toml.DecodeFile(configPath, conf)
 	if err != nil {
 		return nil, err

--- a/pkg/apiregserver/apiregserver.go
+++ b/pkg/apiregserver/apiregserver.go
@@ -228,6 +228,12 @@ func parseIP(addrPort string) *net.IP {
 
 }
 
+func (s *APIRegServer) NewClientConf(c *pb.ClientConf) {
+	if c != nil {
+		s.latestClientConf = c
+	}
+}
+
 func (s *APIRegServer) ListenAndServe() error {
 	r := mux.NewRouter()
 	r.HandleFunc("/register", s.register)

--- a/pkg/dnsregserver/dnsregserver.go
+++ b/pkg/dnsregserver/dnsregserver.go
@@ -3,6 +3,7 @@ package dnsregserver
 import (
 	"encoding/hex"
 	"errors"
+	"sync/atomic"
 
 	"github.com/refraction-networking/conjure/pkg/metrics"
 	"github.com/refraction-networking/conjure/pkg/regprocessor"
@@ -70,7 +71,7 @@ func (s *DNSRegServer) processRequest(reqIn []byte) ([]byte, error) {
 	reqLogger.Tracef("Request received: [%+v]", c2sPayload)
 
 	clientconfOutdated := false
-	if c2sPayload.RegistrationPayload.GetDecoyListGeneration() < s.latestCCGen {
+	if c2sPayload.RegistrationPayload.GetDecoyListGeneration() < atomic.LoadUint32(&s.latestCCGen) {
 		clientconfOutdated = true
 	}
 
@@ -120,5 +121,5 @@ func (f *DNSRegServer) Close() error {
 
 // Close closes the underlying dns responder.
 func (f *DNSRegServer) UpdateLatestCCGen(gen uint32) {
-	f.latestCCGen = gen
+	atomic.StoreUint32(&f.latestCCGen, gen)
 }

--- a/pkg/dnsregserver/dnsregserver.go
+++ b/pkg/dnsregserver/dnsregserver.go
@@ -117,3 +117,8 @@ func (s *DNSRegServer) processRequest(reqIn []byte) ([]byte, error) {
 func (f *DNSRegServer) Close() error {
 	return f.dnsResponder.Close()
 }
+
+// Close closes the underlying dns responder.
+func (f *DNSRegServer) UpdateLatestCCGen(gen uint32) {
+	f.latestCCGen = gen
+}

--- a/pkg/regprocessor/regprocessor.go
+++ b/pkg/regprocessor/regprocessor.go
@@ -254,3 +254,13 @@ func (p *RegProcessor) processC2SWrapper(c2sPayload *pb.C2SWrapper, clientAddr [
 
 	return proto.Marshal(payload)
 }
+
+func (p *RegProcessor) ReloadSubnets() error {
+	phantomSelector, err := lib.GetPhantomSubnetSelector()
+	if err != nil {
+		return err
+	}
+	p.ipSelector = phantomSelector
+
+	return nil
+}

--- a/sysconfig/conjure-app.service
+++ b/sysconfig/conjure-app.service
@@ -18,6 +18,9 @@ EnvironmentFile=/opt/conjure/sysconfig/conjure.conf
 ExecStartPre=/bin/sleep 10
 ExecStart=/opt/conjure/application/application
 
+# send SIGHUP to the station process
+ExecReload=/bin/kill -HUP $MAINPID
+
 # on stop processes will get SIGTERM, and after 10 secs - SIGKILL (default 90)
 TimeoutStopSec=10
 

--- a/sysconfig/conjure-registration-server.service
+++ b/sysconfig/conjure-registration-server.service
@@ -11,6 +11,9 @@ EnvironmentFile=/opt/conjure/sysconfig/conjure.conf
 
 ExecStart=/opt/conjure/cmd/registration-server/registration-server --config /opt/conjure/cmd/registration-server/config.toml
 
+# send SIGHUP to the registration server process
+ExecReload=/bin/kill -HUP $MAINPID
+
 # on stop processes will get SIGTERM, and after 10 secs - SIGKILL (default 90)
 TimeoutStopSec=10
 


### PR DESCRIPTION
clientconf reload for bidirectional API registrar and phantom subnet reload for processor

This is not intended to reload all settings and rebuild the entire server, just the key elements that we would want to reload regularly without restarting the services. 