### PR TITLE
X-Forwarded-For Handling

### DIFF
--- a/pkg/apiregserver/apiregserver.go
+++ b/pkg/apiregserver/apiregserver.go
@@ -39,13 +39,17 @@ var clientIPHeaderNames = []string{
 	// "True-Client-IP",
 }
 
-// Get the first element of the X-Forwarded-For header if it is available, this
-// will be the clients address if intermediate proxies follow X-Forwarded-For
-// specification (as seen here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For).
+// getRemoteAddr get the last entry of the last instance of the X-Forwarded-For header if it
+// is available, this is our best guess at the clients address if intermediate
+// proxies follow X-Forwarded-For specification (as seen here:
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For).
 // Otherwise return the remote address specified in the request.
 //
-// In the future this may need to handle True-Client-IP headers. But in general
-// none of these are to be trusted - https://adam-p.ca/blog/2022/03/x-forwarded-for/
+// In the future this may need to handle True-Client-IP headers, but in general
+// none of these are to be trusted -
+// https://adam-p.ca/blog/2022/03/x-forwarded-for/. If those are enabled in
+// clientIPHeaderNames ensure that the ordering checks them in order of most to
+// least trusted.
 func getRemoteAddr(r *http.Request) net.IP {
 
 	// Default to the clients remote address if no identifying header is provided

--- a/pkg/apiregserver/apiregserver.go
+++ b/pkg/apiregserver/apiregserver.go
@@ -33,18 +33,57 @@ type APIRegServer struct {
 	metrics          *metrics.Metrics
 }
 
+var clientIPHeaderNames = []string{
+	"X-Forwarded-For",
+	// "X-Client-IP",
+	// "True-Client-IP",
+}
+
 // Get the first element of the X-Forwarded-For header if it is available, this
 // will be the clients address if intermediate proxies follow X-Forwarded-For
 // specification (as seen here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For).
 // Otherwise return the remote address specified in the request.
 //
-// In the future this may need to handle True-Client-IP headers.
-func getRemoteAddr(r *http.Request) string {
-	if r.Header.Get("X-Forwarded-For") != "" {
-		addrList := r.Header.Get("X-Forwarded-For")
-		return strings.Trim(strings.Split(addrList, ",")[0], " \t")
+// In the future this may need to handle True-Client-IP headers. But in general
+// none of these are to be trusted - https://adam-p.ca/blog/2022/03/x-forwarded-for/
+func getRemoteAddr(r *http.Request) net.IP {
+
+	// Default to the clients remote address if no identifying header is provided
+	ip := parseIP(r.RemoteAddr)
+
+	// When there are multiple header names in clientIPHeaderNames,
+	// the first valid match is preferred. clientIPHeaderNames should be
+	// configured to use header names that are always provided by the CDN(s) and
+	// not header names that may be passed through from clients.
+	for _, header := range clientIPHeaderNames {
+
+		// In the case where there are multiple headers,
+		// request.Header.Get returns the first header, but we want the
+		// last header; so use request.Header.Values and select the last
+		// value. As per RFC 2616 section 4.2, a proxy must not change
+		// the order of field values, which implies that it should append
+		// values to the last header.
+		values := r.Header.Values(header)
+		if len(values) > 0 {
+			value := values[len(values)-1]
+
+			// Some headers, such as X-Forwarded-For, are a comma-separated
+			// list of IPs (each proxy in a chain). Select the last IP.
+			IPs := strings.Split(value, ",")
+			IP := IPs[len(IPs)-1]
+
+			// Remove optional whitespace surrounding the commas.
+			IP = strings.TrimSpace(IP)
+
+			headerIP := net.ParseIP(IP)
+			if headerIP != nil {
+				ip = headerIP
+				break
+			}
+		}
 	}
-	return r.RemoteAddr
+
+	return ip
 }
 
 func (s *APIRegServer) getC2SFromReq(w http.ResponseWriter, r *http.Request) (*pb.C2SWrapper, error) {
@@ -81,11 +120,15 @@ func (s *APIRegServer) getC2SFromReq(w http.ResponseWriter, r *http.Request) (*p
 func (s *APIRegServer) register(w http.ResponseWriter, r *http.Request) {
 	s.metrics.Add("api_requests_total", 1)
 
-	requestIP := getRemoteAddr(r)
+	clientAddr := getRemoteAddr(r)
+	if clientAddr == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	logFields := log.Fields{"http_method": r.Method, "content_length": r.ContentLength, "registration_type": "unidirectional"}
 	if s.logClientIP {
-		logFields["ip_address"] = requestIP
+		logFields["ip_address"] = clientAddr.String()
 	}
 	reqLogger := s.logger.WithFields(logFields)
 
@@ -99,7 +142,6 @@ func (s *APIRegServer) register(w http.ResponseWriter, r *http.Request) {
 
 	reqLogger = reqLogger.WithField("reg_id", hex.EncodeToString(payload.GetSharedSecret()))
 
-	clientAddr := parseIP(requestIP)
 	var clientAddrBytes = make([]byte, 16)
 	if clientAddr != nil {
 		clientAddrBytes = []byte(clientAddr.To16())
@@ -122,11 +164,16 @@ func (s *APIRegServer) register(w http.ResponseWriter, r *http.Request) {
 
 func (s *APIRegServer) registerBidirectional(w http.ResponseWriter, r *http.Request) {
 	s.metrics.Add("bdapi_requests_total", 1)
-	requestIP := getRemoteAddr(r)
+
+	clientAddr := getRemoteAddr(r)
+	if clientAddr == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	logFields := log.Fields{"http_method": r.Method, "content_length": r.ContentLength, "registration_type": "bidirectional"}
 	if s.logClientIP {
-		logFields["ip_address"] = requestIP
+		logFields["ip_address"] = clientAddr.String()
 	}
 	reqLogger := s.logger.WithFields(logFields)
 
@@ -139,7 +186,6 @@ func (s *APIRegServer) registerBidirectional(w http.ResponseWriter, r *http.Requ
 
 	reqLogger = reqLogger.WithField("reg_id", hex.EncodeToString(payload.GetSharedSecret()))
 
-	clientAddr := parseIP(requestIP)
 	var clientAddrBytes = make([]byte, 16)
 	if clientAddr != nil {
 		clientAddrBytes = []byte(clientAddr.To16())
@@ -214,7 +260,7 @@ func (s *APIRegServer) compareClientConfGen(genNum uint32) *pb.ClientConf {
 
 // parseIP attempts to parse the IP address of a request from string format wether
 // it has a port attached to it or not. Returns nil if parse fails.
-func parseIP(addrPort string) *net.IP {
+func parseIP(addrPort string) net.IP {
 
 	// by default format from r.RemoteAddr is host:port
 	host, _, err := net.SplitHostPort(addrPort)
@@ -224,13 +270,12 @@ func parseIP(addrPort string) *net.IP {
 		if addr == nil {
 			return nil
 		}
-		return &addr
+		return addr
 	}
 
 	addr := net.ParseIP(host)
 
-	return &addr
-
+	return addr
 }
 
 func (s *APIRegServer) NewClientConf(c *pb.ClientConf) {

--- a/pkg/apiregserver/apiregserver.go
+++ b/pkg/apiregserver/apiregserver.go
@@ -88,7 +88,7 @@ func getRemoteAddr(r *http.Request) net.IP {
 					// In that case, cdn_ip == r.RemoteAddr, and we want to walk backward
 					// one more IP.
 					// So here, we ignore if this is just Caddy telling is what we already know:
-					if ip.Equal(headerIP) {
+					if ip.Equal(headerIP) || (i == (len(IPs)-1) && ip.Equal(net.ParseIP("127.0.0.1"))) {
 						continue
 					}
 					ip = headerIP

--- a/pkg/apiregserver/apiregserver.go
+++ b/pkg/apiregserver/apiregserver.go
@@ -39,9 +39,9 @@ var clientIPHeaderNames = []string{
 	// "True-Client-IP",
 }
 
-// getRemoteAddr get the last entry of the last instance of the X-Forwarded-For header if it
-// is available, this is our best guess at the clients address if intermediate
-// proxies follow X-Forwarded-For specification (as seen here:
+// getRemoteAddr gets the last entry of the last instance of the X-Forwarded-For
+// header if it is available, this is our best guess at the clients address if
+// intermediate proxies follow X-Forwarded-For specification (as seen here:
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For).
 // Otherwise return the remote address specified in the request.
 //

--- a/pkg/apiregserver/apiregserver.go
+++ b/pkg/apiregserver/apiregserver.go
@@ -89,7 +89,7 @@ func getRemoteAddr(r *http.Request) net.IP {
 					// one more IP.
 					// So here, we ignore if this is just Caddy telling is what we already know:
 					if ip.Equal(headerIP) ||
-						((i == len(IPs)-1) &&
+						((i == len(IPs)-1) && len(IPs) > 1 &&
 							(ip.Equal(net.ParseIP("127.0.0.1")) ||
 								ip.Equal(net.ParseIP("::1")))) {
 						continue

--- a/pkg/apiregserver/apiregserver.go
+++ b/pkg/apiregserver/apiregserver.go
@@ -74,15 +74,26 @@ func getRemoteAddr(r *http.Request) net.IP {
 			// Some headers, such as X-Forwarded-For, are a comma-separated
 			// list of IPs (each proxy in a chain). Select the last IP.
 			IPs := strings.Split(value, ",")
-			IP := IPs[len(IPs)-1]
+			for i := len(IPs) - 1; i >= 0; i-- {
+				IP := IPs[i]
 
-			// Remove optional whitespace surrounding the commas.
-			IP = strings.TrimSpace(IP)
+				// Remove optional whitespace surrounding the commas.
+				IP = strings.TrimSpace(IP)
 
-			headerIP := net.ParseIP(IP)
-			if headerIP != nil {
-				ip = headerIP
-				break
+				headerIP := net.ParseIP(IP)
+				if headerIP != nil {
+					// Caddy appends an X-Forward-For from the client (potentially CDN)
+					// We configure Caddy to trust the domain-fronted proxies,
+					// which will give us a list of real_client_ip, cdn_ip.
+					// In that case, cdn_ip == r.RemoteAddr, and we want to walk backward
+					// one more IP.
+					// So here, we ignore if this is just Caddy telling is what we already know:
+					if ip.Equal(headerIP) {
+						continue
+					}
+					ip = headerIP
+					break
+				}
 			}
 		}
 	}

--- a/pkg/apiregserver/apiregserver.go
+++ b/pkg/apiregserver/apiregserver.go
@@ -89,8 +89,9 @@ func getRemoteAddr(r *http.Request) net.IP {
 					// one more IP.
 					// So here, we ignore if this is just Caddy telling is what we already know:
 					if ip.Equal(headerIP) ||
-						ip.Equal(net.ParseIP("127.0.0.1")) ||
-						ip.Equal(net.ParseIP("::1")) {
+						((i == len(IPs)-1) &&
+							(ip.Equal(net.ParseIP("127.0.0.1")) ||
+								ip.Equal(net.ParseIP("::1")))) {
 						continue
 					}
 					ip = headerIP

--- a/pkg/apiregserver/apiregserver.go
+++ b/pkg/apiregserver/apiregserver.go
@@ -88,7 +88,9 @@ func getRemoteAddr(r *http.Request) net.IP {
 					// In that case, cdn_ip == r.RemoteAddr, and we want to walk backward
 					// one more IP.
 					// So here, we ignore if this is just Caddy telling is what we already know:
-					if ip.Equal(headerIP) || (i == (len(IPs)-1) && ip.Equal(net.ParseIP("127.0.0.1"))) {
+					if ip.Equal(headerIP) ||
+						ip.Equal(net.ParseIP("127.0.0.1")) ||
+						ip.Equal(net.ParseIP("::1")) {
 						continue
 					}
 					ip = headerIP

--- a/pkg/apiregserver/apiregserver_test.go
+++ b/pkg/apiregserver/apiregserver_test.go
@@ -257,8 +257,7 @@ func TestAPIGetClientAddr(t *testing.T) {
 	// 	t.Log(xff, v)
 	// }
 	ip = getRemoteAddr(req)
-	require.Equal(t, net.ParseIP("8.8.8.8"), ip, "expected %s got %s", "192.168.1.1", ip)
-
+	require.Equal(t, net.ParseIP("8.8.8.8"), ip, "expected %s got %s", "8.8.8.8", ip)
 }
 
 func TestCorrectUnidirectionalAPI(t *testing.T) {

--- a/pkg/apiregserver/apiregserver_test.go
+++ b/pkg/apiregserver/apiregserver_test.go
@@ -225,14 +225,23 @@ func TestAPIGetClientAddr(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	require.Nil(t, err)
 
+	// If only the RemoteAddress is available we should use that.
 	req.RemoteAddr = "10.0.0.0:80"
 	ip := getRemoteAddr(req)
 	require.Equal(t, net.ParseIP("10.0.0.0"), ip, "expected %s got %s", "10.0.0.0", ip)
 
+	// if an XFF address is available we should use that if it parses properly as an IP
 	req.Header.Add(xff, "192.168.1.1")
 	ip = getRemoteAddr(req)
 	require.Equal(t, net.ParseIP("192.168.1.1"), ip, "expected %s got %s", "192.168.1.1", ip)
 
+	// if an XFF address is available, but does not parse as a valid IP we should return the
+	// remote address.
+	req.Header.Set(xff, "127.example.com")
+	ip = getRemoteAddr(req)
+	require.Equal(t, net.ParseIP("10.0.0.0"), ip, "expected %s got %s", "10.0.0.0", ip)
+
+	// If more than one IP is provided (i.e. multiple proxy hops) take the last one
 	req.Header.Set(xff, "127.0.0.1, 192.168.0.0")
 	ip = getRemoteAddr(req)
 	require.Equal(t, net.ParseIP("192.168.0.0"), ip, "expected %s got %s", "192.168.0.0", ip)

--- a/pkg/apiregserver/apiregserver_test.go
+++ b/pkg/apiregserver/apiregserver_test.go
@@ -218,22 +218,38 @@ func BenchmarkRegistration(b *testing.B) {
 	}
 }
 
+var xff = "X-Forwarded-For"
+
 func TestAPIGetClientAddr(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	require.Nil(t, err)
 
-	req.RemoteAddr = "10.0.0.0"
-	require.Equal(t, "10.0.0.0", getRemoteAddr(req))
+	req.RemoteAddr = "10.0.0.0:80"
+	ip := getRemoteAddr(req)
+	require.Equal(t, net.ParseIP("10.0.0.0"), ip, "expected %s got %s", "10.0.0.0", ip)
 
-	req.Header.Add("X-Forwarded-For", "192.168.1.1")
-	require.Equal(t, "192.168.1.1", getRemoteAddr(req))
+	req.Header.Add(xff, "192.168.1.1")
+	ip = getRemoteAddr(req)
+	require.Equal(t, net.ParseIP("192.168.1.1"), ip, "expected %s got %s", "192.168.1.1", ip)
 
-	req.Header.Set("X-Forwarded-For", "127.0.0.1, 192.168.0.0")
-	require.Equal(t, "127.0.0.1", getRemoteAddr(req))
+	req.Header.Set(xff, "127.0.0.1, 192.168.0.0")
+	ip = getRemoteAddr(req)
+	require.Equal(t, net.ParseIP("192.168.0.0"), ip, "expected %s got %s", "192.168.0.0", ip)
 
-	req.Header.Set("X-Forwarded-For", "127.0.0.1,192.168.0.0")
-	require.Equal(t, "127.0.0.1", getRemoteAddr(req))
+	req.Header.Set(xff, "127.0.0.1,192.168.0.0")
+	ip = getRemoteAddr(req)
+	require.Equal(t, net.ParseIP("192.168.0.0"), ip, "expected %s got %s", "192.168.0.0", ip)
+
+	// Add a second header X Ignore header with different value, we want to use the
+	// last value from the last instance instance, i.e. the previous
+	req.Header.Add(xff, "1.1.1.1,8.8.8.8")
+	// for _, v := range req.Header.Values(xff) {
+	// 	t.Log(xff, v)
+	// }
+	ip = getRemoteAddr(req)
+	require.Equal(t, net.ParseIP("8.8.8.8"), ip, "expected %s got %s", "192.168.1.1", ip)
+
 }
 
 func TestCorrectUnidirectionalAPI(t *testing.T) {


### PR DESCRIPTION
## Problem
Our current `X-Forwarded-For` (XFF) handling is not properly implemented to get the last client IP address included by proxy hops. 

## Solution

Update the handling of XFF (and potentially other client IP) headers in the API registrar.  

For reference: 
- https://adam-p.ca/blog/2022/03/x-forwarded-for/

Changes:
- `parseIP` returns  `net.IP` instead of `*net.IP` - downstream calls can handle pass by reference if needed.
- `getRemoteAddr` returns `net.IP` (or `nil`) instead of `string` - all uses need a parsed IP anyways, also allows a quick failure
-  `getRemoteAddr` updated to follow better practices for parsing and handling real client IP headers
- `TestAPIGetClientAddr` updated to reflect new behavior