### PR TITLE
Halfpipe Timeout Handling

### DIFF
--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -105,6 +105,19 @@ func halfPipe(src net.Conn, dst net.Conn,
 				}
 				break
 			}
+
+			// refresh stall timeout - set both because it only happens on write
+			// so if connection is sending traffic unidirectionally we prevent
+			// the receiving side from timing out.
+			err := src.SetDeadline(time.Now().Add(proxyStallTimeout))
+			if err != nil {
+				logger.Errorln("error setting deadline for src conn: ", tag)
+			}
+			err = dst.SetDeadline(time.Now().Add(proxyStallTimeout))
+			if err != nil {
+				logger.Errorln("error setting deadline for dst conn: ", tag)
+			}
+
 		}
 		return totWritten, err
 

--- a/application/lib/proxies_test.go
+++ b/application/lib/proxies_test.go
@@ -7,12 +7,17 @@ package lib
 import (
 	"bytes"
 	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
 	"net"
 	"os"
 	"sync"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/refraction-networking/conjure/application/log"
 )
@@ -113,4 +118,155 @@ func (m *mockConn) SetReadDeadline(t time.Time) error {
 
 func (m *mockConn) SetWriteDeadline(t time.Time) error {
 	return errNotExist
+}
+
+func TestHalfpipeDeadlineEcho(t *testing.T) {
+	if os.Getenv("HALFPIPE") == "" {
+		t.Skip("Skipping slow tests involving halfpipe timeouts")
+	}
+
+	clientClient, clientStation := net.Pipe()
+	stationCovert, covertCovert := net.Pipe()
+
+	logger := log.New(os.Stdout, "", 0)
+	logger.SetLevel(log.TraceLevel)
+	wg := sync.WaitGroup{}
+	oncePrintErr := sync.Once{}
+	wg.Add(2)
+
+	go halfPipe(clientStation, stationCovert, &wg, &oncePrintErr, logger, "Up "+"XXXXXX")
+	go halfPipe(stationCovert, clientStation, &wg, &oncePrintErr, logger, "Down "+"XXXXXX")
+
+	go func() {
+		defer covertCovert.Close()
+		io.Copy(covertCovert, covertCovert)
+	}()
+
+	start := time.Now()
+	for i := 0; i < 10; i++ {
+
+		_, err := clientClient.Write([]byte(fmt.Sprintf("%d", i)))
+		if err != nil {
+			t.Fatalf("received '%v' at client", err)
+		}
+
+		b := make([]byte, 10)
+		n, err := clientClient.Read(b)
+		if errors.Is(err, io.EOF) {
+			t.Fatalf("received EOF at client")
+		} else if e, ok := err.(net.Error); ok && e.Timeout() {
+			t.Fatalf("received Timeout at client")
+		} else if err != nil {
+			t.Fatalf("received '%v' at client", err)
+		}
+
+		t.Logf("%s, %d - %s", time.Since(start), n, string(b))
+
+		time.Sleep(4 * time.Second)
+	}
+
+	clientClient.Close()
+	wg.Wait()
+}
+
+func TestHalfpipeDeadlineUpload(t *testing.T) {
+	if os.Getenv("HALFPIPE") == "" {
+		t.Skip("Skipping slow tests involving halfpipe timeouts")
+	}
+
+	clientClient, clientStation := net.Pipe()
+	stationCovert, covertCovert := net.Pipe()
+
+	logger := log.New(os.Stdout, "", 0)
+	logger.SetLevel(log.TraceLevel)
+	wg := sync.WaitGroup{}
+	oncePrintErr := sync.Once{}
+	wg.Add(2)
+
+	go halfPipe(clientStation, stationCovert, &wg, &oncePrintErr, logger, "Up "+"XXXXXX")
+	go halfPipe(stationCovert, clientStation, &wg, &oncePrintErr, logger, "Down "+"XXXXXX")
+
+	go func() {
+		defer covertCovert.Close()
+		io.Copy(ioutil.Discard, covertCovert)
+	}()
+
+	start := time.Now()
+	for i := 0; i < 10; i++ {
+
+		n, err := clientClient.Write([]byte(fmt.Sprintf("%d", i)))
+		if errors.Is(err, io.EOF) {
+			t.Fatalf("received EOF at client")
+		} else if e, ok := err.(net.Error); ok && e.Timeout() {
+			t.Fatalf("received Timeout at client")
+		} else if err != nil {
+			t.Fatalf("received '%v' at client", err)
+		}
+
+		t.Logf("%s, %d %d", time.Since(start), n, i)
+
+		time.Sleep(4 * time.Second)
+	}
+
+	clientClient.Close()
+	covertCovert.Close()
+	wg.Wait()
+}
+
+// Test that we actually timeout after one side (client) stalls too long.
+func TestHalfpipeDeadlineActual(t *testing.T) {
+	if os.Getenv("HALFPIPE") == "" {
+		t.Skip("Skipping slow tests involving halfpipe timeouts")
+	}
+
+	clientClient, clientStation := net.Pipe()
+	stationCovert, covertCovert := net.Pipe()
+
+	logger := log.New(os.Stdout, "", 0)
+	logger.SetLevel(log.TraceLevel)
+	wg := sync.WaitGroup{}
+	oncePrintErr := sync.Once{}
+	wg.Add(2)
+
+	go halfPipe(clientStation, stationCovert, &wg, &oncePrintErr, logger, "Up "+"XXXXXX")
+	go halfPipe(stationCovert, clientStation, &wg, &oncePrintErr, logger, "Down "+"XXXXXX")
+
+	var serverErr error
+	go func() {
+		defer covertCovert.Close()
+		for {
+			b := make([]byte, 10)
+			_, serverErr = covertCovert.Read(b)
+			if serverErr != nil {
+				return
+			}
+		}
+	}()
+
+	start := time.Now()
+	for i := 0; i < 3; i++ {
+
+		n, err := clientClient.Write([]byte(fmt.Sprintf("%d", i)))
+		if errors.Is(err, io.EOF) {
+			t.Fatalf("received EOF at client")
+		} else if e, ok := err.(net.Error); ok && e.Timeout() {
+			t.Fatalf("received Timeout at client")
+		} else if err != nil {
+			t.Fatalf("received '%v' at client", err)
+		}
+
+		t.Logf("%s, %d %d", time.Since(start), n, i)
+
+		time.Sleep(4 * time.Second)
+	}
+
+	// sleep 27 + 4 = 31 > proxyStallTimeout
+	time.Sleep(27 * time.Second)
+
+	// covertStation will Timeout and send an EOF to covertCovert
+	require.ErrorIs(t, io.EOF, serverErr)
+
+	clientClient.Close()
+	covertCovert.Close()
+	wg.Wait()
 }


### PR DESCRIPTION
## Problem

The calls to SetDeadline were intended to close tunnels when one either side dissapears for more than 30 seconds. However, the timeouts have been applied improperly and they close the connection after 30 seconds regardless  of whether the connection is seeing bytes transferred or not.

## Solution

Reset conn Deadline on a write in either direction. 

Added tests to show that this woks in the cases where:

- the client and station are writing, to each other - the connection stays open.
- unidirectional flow, where only client is writing i.e. covert connection doesn't timeout for not writing
- The timeout does apply if one no bytes are written for more than `proxyStallTimeout` (30s)

These tests are disabled by default because they take >30s each to run. To run them you can set the environment variable `HALPIPE`: 
```sh
cd application/lib
HALFPIPE="true" go test -v -run TestHalfpipeDeadline
```