### PR TITLE
Registation ingest stats crash

### DIFF
--- a/application/lib/registration_stats.go
+++ b/application/lib/registration_stats.go
@@ -95,8 +95,8 @@ func (s *RegistrationStats) Reset() {
 	}()
 
 	func() {
-		s.genMutex.Lock()
-		defer s.genMutex.Unlock()
+		s.lvMutex.Lock()
+		defer s.lvMutex.Unlock()
 		s.lvStats = map[uint32]*libverStats{}
 	}()
 


### PR DESCRIPTION
copy-paste error in mutex name lead to station crash

``` log
Nov 16 12:58:17 decoy-tap systemd[1]: conjure-app.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Nov 16 12:58:17 decoy-tap conjure[1610467]:         /home/jmwample/conjure/application/lib/registration_ingest.go:58 +0x170
Nov 16 12:58:17 decoy-tap conjure[1610467]: created by github.com/refraction-networking/conjure/application/lib.(*RegistrationManager).HandleRegUpdates
Nov 16 12:58:17 decoy-tap conjure[1610467]:         /home/jmwample/conjure/application/lib/registration_ingest.go:111 +0x214
Nov 16 12:58:17 decoy-tap conjure[1610467]: github.com/refraction-networking/conjure/application/lib.(*RegistrationManager).startIngestThread(0xc000234340, {0x9f6ad8, 0xc000234380}, 0xc000034240, 0x0?)
Nov 16 12:58:17 decoy-tap conjure[1610467]:         /home/jmwample/conjure/application/lib/registration_ingest.go:224 +0xaf2
Nov 16 12:58:17 decoy-tap conjure[1610467]: github.com/refraction-networking/conjure/application/lib.(*RegistrationManager).ingestRegistration(0xc000234340, 0xc0067288c0)
Nov 16 12:58:17 decoy-tap conjure[1610467]:         /home/jmwample/conjure/application/lib/registration_stats.go:365 +0xf3
Nov 16 12:58:17 decoy-tap conjure[1610467]: github.com/refraction-networking/conjure/application/lib.(*RegistrationStats).AddRegStats(0xc00018e900, 0x10?)
Nov 16 12:58:17 decoy-tap conjure[1610467]:         /home/jmwample/conjure/application/lib/registration_stats.go:364 +0x10e
Nov 16 12:58:17 decoy-tap conjure[1610467]: github.com/refraction-networking/conjure/application/lib.(*RegistrationStats).AddRegStats.func3(0xc00018e900, 0x488?)

```