### PR TITLE
Obfs4 stateDir handling 

### DIFF
--- a/application/transports/wrapping/obfs4/obfs4.go
+++ b/application/transports/wrapping/obfs4/obfs4.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"net"
-	"os"
 
 	pt "git.torproject.org/pluggable-transports/goptlib.git"
 	dd "github.com/refraction-networking/conjure/application/lib"
@@ -49,12 +48,8 @@ func (Transport) WrapConnection(data *bytes.Buffer, c net.Conn, phantom net.IP, 
 		args.Add("drbg-seed", seed.Hex())
 
 		t := &obfs4.Transport{}
-		stateDir, err := os.MkdirTemp("", "")
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create tmp-dir for WrapConn")
-		}
 
-		factory, err := t.ServerFactory(stateDir, &args)
+		factory, err := t.ServerFactory("", &args)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create server factory: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,11 @@ require (
 	github.com/dchest/siphash v1.2.3 // indirect
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/gorilla/mux v1.8.0
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/mroth/weightedrand v0.4.1
 	github.com/pebbe/zmq4 v1.2.7
 	github.com/pelletier/go-toml v1.9.4
 	github.com/refraction-networking/gotapdance v1.3.1
-	github.com/refraction-networking/utls v1.1.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.7.1
 	gitlab.com/yawning/obfs4.git v0.0.0-20220204003609-77af0cba934d
@@ -22,3 +21,7 @@ require (
 	google.golang.org/grpc v1.41.0
 	google.golang.org/protobuf v1.28.0
 )
+
+// replace gitlab.com/yawning/obfs4.git => github.com/jmwample/obfs4.git v0.0.0-20230113193642-07b111e6b208
+
+replace gitlab.com/yawning/obfs4.git => github.com/jmwample/obfs4 v0.0.0-20230113193642-07b111e6b208

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
+github.com/jmwample/obfs4 v0.0.0-20230113193642-07b111e6b208 h1:6nxlCjgsYnjYafKVqvElKbFL+95Kgg5YWT/GuXUNoD8=
+github.com/jmwample/obfs4 v0.0.0-20230113193642-07b111e6b208/go.mod h1:9GcM8QNU9/wXtEEH2q8bVOnPI7FtIF6VVLzZ1l6Hgf8=
 github.com/keltia/proxy v0.9.3/go.mod h1:fLU4DmBPG0oh0md9fWggE2oG2m7Lchv3eim+GiO3pZY=
 github.com/keltia/ripe-atlas v0.0.0-20211221125000-f6eb808d5dc6/go.mod h1:zYa+dM8811qRhclezc/AKX9imyQwPjjSk2cH0xTgTag=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
@@ -112,8 +114,6 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/refraction-networking/gotapdance v1.3.1 h1:nccj5T6e10xdixUtuMGzkGhtbkcuHnNpJO12zenzeXo=
 github.com/refraction-networking/gotapdance v1.3.1/go.mod h1:8IRTeIDGY+2JbwCOB4IOpQA5LifvuI/dUKippcvhtYw=
 github.com/refraction-networking/utls v1.0.0/go.mod h1:tz9gX959MEFfFN5whTIocCLUG57WiILqtdVxI8c6Wj0=
-github.com/refraction-networking/utls v1.1.0 h1:dKXJwSqni/t5csYJ+aQcEgqB7AMWYi6EUc9u3bEmjX0=
-github.com/refraction-networking/utls v1.1.0/go.mod h1:tz9gX959MEFfFN5whTIocCLUG57WiILqtdVxI8c6Wj0=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/sergeyfrolov/bsbuffer v0.0.0-20180903213811-94e85abb8507/go.mod h1:DbI1gxrXI2jRGw7XGEUZQOOMd6PsnKzRrCKabvvMrwM=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -129,8 +129,6 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 gitlab.com/yawning/edwards25519-extra.git v0.0.0-20211229043746-2f91fcc9fbdb h1:qRSZHsODmAP5qDvb3YsO7Qnf3TRiVbGxNG/WYnlM4/o=
 gitlab.com/yawning/edwards25519-extra.git v0.0.0-20211229043746-2f91fcc9fbdb/go.mod h1:gvdJuZuO/tPZyhEV8K3Hmoxv/DWud5L4qEQxfYjEUTo=
-gitlab.com/yawning/obfs4.git v0.0.0-20220204003609-77af0cba934d h1:tJ8F7ABaQ3p3wjxwXiWSktVDgjZEXkvaRawd2rIq5ws=
-gitlab.com/yawning/obfs4.git v0.0.0-20220204003609-77af0cba934d/go.mod h1:9GcM8QNU9/wXtEEH2q8bVOnPI7FtIF6VVLzZ1l6Hgf8=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
Creates a _somewhat_ more permanent fix for #132. This makes use of a fix that I implemented in a fork of the obfs4 repo which treats an empty statedir string as `"Do NOT use local state"` rather than treating it as `"./"`.  To me this seems like a better and more explicit way to handle state (or lack there-of). For now I have added a PR against the upstream obfs4 repository https://github.com/Yawning/obfs4/pull/35 and added a `replace` in the `go.mod` to use my fork in the hopes that it  will be accepted soon at which time we can just remove the `replace`. Alternatively if that PR leads to some other fix we can support it here in a future PR.


To re-iterate the problem: We use independent keys for each session making a connection using the obfs4 transport with the keys derived from the shared secret of the session. We want the server to be usable ONLY by the individual client that negotiated the session. However, since there is no option to not use `stateDir` in the `ServerFactory`, each session must create a unique directory that it can use as the `stateDir` otherwise one session might parse another sessions secrets from the state files. The fix allows us to bypass the steps of parsing arguments from and writing arguments to the state directory.

related: #135 