### PR TITLE
Github Actions update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: go/src/github.com/refraction-networking/conjure
           submodules: recursive
@@ -55,7 +55,7 @@ jobs:
           echo "Station successfully built"
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
 
@@ -77,7 +77,7 @@ jobs:
           cd $GITHUB_WORKSPACE && tar -czf conjure-station.tar.gz bin
 
       - name: Save build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: conjure-station.tar.gz
           path: |

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -13,11 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.16.x, 1.17.x, 1.18.x]
+        go-version: [1.16.x, 1.17.x, 1.18.x, stable]
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: go/src/github.com/refraction-networking/conjure
 
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get install libzmq3-dev libssl-dev pkg-config libgmp3-dev -y -q
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -53,14 +53,14 @@ jobs:
     name: Format and Lint with golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install deps
         run: |
           sudo apt-get update
           sudo apt-get install protobuf-compiler software-properties-common -y -q
           sudo apt-get install libzmq3-dev libssl-dev pkg-config libgmp3-dev -y -
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           args: --disable structcheck,govet

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
           - { rust: stable,           os: ubuntu-20.04 }
           - { rust: nightly,          os: ubuntu-latest }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install deps
         run: |
@@ -46,7 +46,7 @@ jobs:
     env:
       RUSTFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install deps
         run: |
           sudo apt-get update
@@ -63,7 +63,7 @@ jobs:
     name: Verify code formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hecrj/setup-rust-action@v1
         with:
           components: rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,10 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # ubuntu-latest is another name for ubuntu-20.04
-          # - { rust: stable,           os: ubuntu-latest }
-          - { rust: stable,           os: ubuntu-18.04 }
+          # ubuntu-latest is another name for ubuntu-22.04
           - { rust: stable,           os: ubuntu-20.04 }
+          - { rust: stable,           os: ubuntu-22.04 }
           - { rust: nightly,          os: ubuntu-latest }
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
It seems like all `v2` actions ran using node12 which lost support in the fall. the github actions warn that all actions should be updated to use node16. This seems to mean that all actions need updated to `v3`.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/