### PR TITLE
Event stats with GeoIP info

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -63,4 +63,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --disable structcheck,govet
+          args: -v --disable structcheck,govet

--- a/application/config.toml
+++ b/application/config.toml
@@ -99,6 +99,11 @@ detector_filter_list = [
 # Log level, one of the following: info, error, warn, debug, trace
 log_level = "error"
 
+# MaxMind Database files - if empty then the Empty Geoip lookup will be used
+# (effictvely disaling lookup).
+geoip_cc_db_path = ""
+geoip_asn_db_path = ""
+
 ### ZMQ sockets to connect to and subscribe
 
 ## Registration API

--- a/application/config.toml
+++ b/application/config.toml
@@ -99,8 +99,9 @@ detector_filter_list = [
 # Log level, one of the following: info, error, warn, debug, trace
 log_level = "error"
 
-# MaxMind Database files - if empty then the Empty Geoip lookup will be used
-# (effictvely disaling lookup).
+# MaxMind Database files - if empty then the Empty Geoip lookup will be used (effictvely disaling
+# lookup). The default path used by the maxmind geoiupdate tool is `/usr/local/share/GeoIP`.
+# repo - https://github.com/maxmind/geoipupdate/blob/main/pkg/geoipupdate/defaults_notwin.go#L15
 geoip_cc_db_path = ""
 geoip_asn_db_path = ""
 

--- a/application/geoip/empty.go
+++ b/application/geoip/empty.go
@@ -1,0 +1,29 @@
+package geoip
+
+import (
+	"errors"
+	"net"
+)
+
+var (
+	// ErrNoDatabasesProvided indicates that no databases were provided so we are going to return a
+	// struct implementing the Database interface so stations that don't support geoip can still
+	// operate normally.
+	ErrNoDatabasesProvided = errors.New("no databases provided - using empty Geoip")
+)
+
+// EmptyDatabase provides the Geoip functionality that we need using the MaxMind GeoIP service
+type EmptyDatabase struct {
+}
+
+// ASN returns the Autonomous System Number (ASN) associated with the provided IP.
+// The Empty Database Returns 0.
+func (mmdb *EmptyDatabase) ASN(ip net.IP) (uint, error) {
+	return 0, nil
+}
+
+// CC returns the ISO country code associated with the provided IP. The Empty Database Returns an
+// empty string.
+func (mmdb *EmptyDatabase) CC(ip net.IP) (string, error) {
+	return "", nil
+}

--- a/application/geoip/geoip.go
+++ b/application/geoip/geoip.go
@@ -1,0 +1,114 @@
+package geoip
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/oschwald/geoip2-golang"
+)
+
+// Database provides the minimal useful interface for looking up relevant information so we
+// aren't tied tp the types / interface of a specific GeoIP library
+type Database interface {
+	ASN(ip net.IP) (uint, error)
+	CC(ip net.IP) (string, error)
+}
+
+var (
+	// ErrMissingDB indicates that one or more of the utility databases was not provided. The wrapped
+	// error message should indicate which database was missing.
+	ErrMissingDB = errors.New("missing one or more geoip DBs")
+)
+
+// DBConfig contains options used for GeoIP lookup - including paths to database files
+type DBConfig struct {
+	CCDBPath  string `toml:"geoip_cc_db_path"`
+	ASNDBPath string `toml:"geoip_asn_db_path"`
+}
+
+// New returns a database given a config. If the provided config is nil, the Empty Database will
+// be returned.
+func New(conf *DBConfig) (Database, error) {
+
+	// If no config is provided or the config provided contains no DB paths return the empty db.
+	if conf == nil {
+		return &EmptyDatabase{}, fmt.Errorf("%w: no config", ErrMissingDB)
+	} else if conf.ASNDBPath == "" && conf.CCDBPath == "" {
+		return &EmptyDatabase{}, fmt.Errorf("%w: no asn or cc db files", ErrMissingDB)
+	}
+
+	db := &maxMindDatabase{DBConfig: conf}
+
+	err := db.init()
+	if errors.Is(err, ErrMissingDB) {
+		return db, err
+	} else if err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}
+
+// maxMindDatabase provides the GeoIP functionality that we need using the MaxMind GeoIP service
+type maxMindDatabase struct {
+	*DBConfig
+
+	asnReader *geoip2.Reader
+	ccReader  *geoip2.Reader
+}
+
+// ASN returns the Autonomous System Number (ASN) associated with the provided IP.
+func (mmdb *maxMindDatabase) init() error {
+	var err error
+
+	if mmdb.ASNDBPath != "" {
+		mmdb.asnReader, err = geoip2.Open(mmdb.DBConfig.ASNDBPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	if mmdb.CCDBPath != "" {
+		mmdb.ccReader, err = geoip2.Open(mmdb.DBConfig.CCDBPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	if mmdb.ccReader == nil && mmdb.asnReader != nil {
+		return fmt.Errorf("%w: no cc db file", ErrMissingDB)
+	} else if mmdb.ccReader != nil && mmdb.asnReader == nil {
+		return fmt.Errorf("%w: no asn db file", ErrMissingDB)
+	}
+
+	return nil
+}
+
+// ASN returns the Autonomous System Number (ASN) associated with the provided IP.
+func (mmdb *maxMindDatabase) ASN(ipAddress net.IP) (uint, error) {
+	if mmdb == nil || mmdb.asnReader == nil {
+		return 0, nil
+	}
+
+	record, err := mmdb.asnReader.ASN(ipAddress)
+	if err != nil {
+		return 0, err
+	}
+
+	return record.AutonomousSystemNumber, nil
+}
+
+// CC returns the ISO country code associated with the provided IP.
+func (mmdb *maxMindDatabase) CC(ipAddress net.IP) (string, error) {
+	if mmdb == nil || mmdb.ccReader == nil {
+		return "", nil
+	}
+
+	record, err := mmdb.ccReader.Country(ipAddress)
+	if err != nil {
+		return "", err
+	}
+
+	return record.Country.IsoCode, nil
+}

--- a/application/geoip/geoip_test.go
+++ b/application/geoip/geoip_test.go
@@ -1,0 +1,109 @@
+package geoip
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeoIPMaxMind(t *testing.T) {
+	dbDir := "/opt/mmdb/"
+	c := &DBConfig{
+		ASNDBPath: filepath.Join(dbDir, "GeoLite2-ASN.mmdb"),
+		CCDBPath:  filepath.Join(dbDir, "GeoLite2-Country.mmdb"),
+	}
+
+	db, err := New(c)
+	require.Nil(t, err)
+
+	// If you are using strings that may be invalid, check that ip is not nil
+	ip := net.ParseIP("81.2.69.142")
+	cc, err := db.CC(ip)
+	require.Nil(t, err)
+
+	asn, err := db.ASN(ip)
+	require.Nil(t, err)
+
+	t.Log(cc)
+	t.Log(asn)
+}
+
+func TestGeoIPNoASN(t *testing.T) {
+	dbDir := "/opt/mmdb/"
+	c := &DBConfig{
+		CCDBPath: filepath.Join(dbDir, "GeoLite2-Country.mmdb"),
+	}
+
+	db, err := New(c)
+	require.ErrorIs(t, err, ErrMissingDB)
+	require.NotNil(t, db)
+
+	// If you are using strings that may be invalid, check that ip is not nil
+	ip := net.ParseIP("81.2.69.142")
+	cc, err := db.CC(ip)
+	require.Nil(t, err)
+	require.Equal(t, "GB", cc)
+
+	asn, err := db.ASN(ip)
+	require.Nil(t, err)
+	require.Equal(t, uint(0), asn)
+}
+
+func TestGeoIPNoCC(t *testing.T) {
+	dbDir := "/opt/mmdb/"
+	c := &DBConfig{
+		ASNDBPath: filepath.Join(dbDir, "GeoLite2-ASN.mmdb"),
+		CCDBPath:  "",
+	}
+
+	db, err := New(c)
+	require.ErrorIs(t, err, ErrMissingDB)
+	require.NotNil(t, db)
+
+	// If you are using strings that may be invalid, check that ip is not nil
+	ip := net.ParseIP("81.2.69.142")
+	cc, err := db.CC(ip)
+	require.Nil(t, err)
+	require.Equal(t, "", cc)
+
+	asn, err := db.ASN(ip)
+	require.Nil(t, err)
+	require.Equal(t, uint(20712), asn)
+}
+
+func TestGeoIPEmpty(t *testing.T) {
+	c := &DBConfig{
+		ASNDBPath: "",
+		CCDBPath:  "",
+	}
+
+	db, err := New(nil)
+	require.ErrorIs(t, err, ErrMissingDB)
+
+	db, err = New(c)
+	require.ErrorIs(t, err, ErrMissingDB)
+	require.NotNil(t, db)
+
+	// If you are using strings that may be invalid, check that ip is not nil
+	ip := net.ParseIP("81.2.69.142")
+	cc, err := db.CC(ip)
+	require.Nil(t, err)
+	require.Equal(t, "", cc)
+
+	asn, err := db.ASN(ip)
+	require.Nil(t, err)
+	require.Equal(t, uint(0), asn)
+}
+
+func TestGeoIPNonMissingError(t *testing.T) {
+	c := &DBConfig{
+		ASNDBPath: "",
+		CCDBPath:  "abcdef",
+	}
+
+	db, err := New(c)
+	require.NotErrorIs(t, err, ErrMissingDB)
+	require.Nil(t, db)
+}

--- a/application/geoip/geoip_test.go
+++ b/application/geoip/geoip_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGeoIPMaxMind(t *testing.T) {
+func DisabledTestGeoIPMaxMind(t *testing.T) {
 	dbDir := "/opt/mmdb/"
 	c := &DBConfig{
 		ASNDBPath: filepath.Join(dbDir, "GeoLite2-ASN.mmdb"),
@@ -30,7 +30,7 @@ func TestGeoIPMaxMind(t *testing.T) {
 	t.Log(asn)
 }
 
-func TestGeoIPNoASN(t *testing.T) {
+func DisabledTestGeoIPNoASN(t *testing.T) {
 	dbDir := "/opt/mmdb/"
 	c := &DBConfig{
 		CCDBPath: filepath.Join(dbDir, "GeoLite2-Country.mmdb"),
@@ -51,7 +51,7 @@ func TestGeoIPNoASN(t *testing.T) {
 	require.Equal(t, uint(0), asn)
 }
 
-func TestGeoIPNoCC(t *testing.T) {
+func DisabledTestGeoIPNoCC(t *testing.T) {
 	dbDir := "/opt/mmdb/"
 	c := &DBConfig{
 		ASNDBPath: filepath.Join(dbDir, "GeoLite2-ASN.mmdb"),
@@ -79,10 +79,10 @@ func TestGeoIPEmpty(t *testing.T) {
 		CCDBPath:  "",
 	}
 
-	db, err := New(nil)
+	_, err := New(nil)
 	require.ErrorIs(t, err, ErrMissingDB)
 
-	db, err = New(c)
+	db, err := New(c)
 	require.ErrorIs(t, err, ErrMissingDB)
 	require.NotNil(t, db)
 

--- a/application/lib/config_test.go
+++ b/application/lib/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
+	"github.com/refraction-networking/conjure/application/geoip"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,4 +21,8 @@ func TestConfigParse(t *testing.T) {
 	lc := c.LivenessConfig()
 	require.NotEqual(t, "", lc.CacheDuration)
 	require.NotEqual(t, "", lc.CacheDurationNonLive)
+
+	var db geoip.Database
+	require.NotNil(t, c.RegConfig.DBConfig)
+	require.IsType(t, db, c.RegConfig.DBConfig)
 }

--- a/application/lib/config_test.go
+++ b/application/lib/config_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
-	"github.com/refraction-networking/conjure/application/geoip"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +21,7 @@ func TestConfigParse(t *testing.T) {
 	require.NotEqual(t, "", lc.CacheDuration)
 	require.NotEqual(t, "", lc.CacheDurationNonLive)
 
-	var db geoip.Database
+	// var db geoip.Database
 	require.NotNil(t, c.RegConfig.DBConfig)
-	require.IsType(t, db, c.RegConfig.DBConfig)
+	// require.IsType(t, db, c.RegConfig.DBConfig)
 }

--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -176,6 +176,10 @@ func halfPipe(src net.Conn, dst net.Conn,
 // Proxy take a registration and a net.Conn and forwards client traffic to the
 // clients covert destination.
 func Proxy(reg *DecoyRegistration, clientConn net.Conn, logger *log.Logger) {
+
+	// New successful connection to station for this registration
+	atomic.AddInt64(&reg.tunnelCount, 1)
+
 	covertConn, err := net.Dial("tcp", reg.Covert)
 	if errors.Is(err, syscall.ECONNRESET) {
 		err = fmt.Errorf("rst")

--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -283,14 +283,14 @@ type tunnelStats struct {
 	PhantomAddr    string
 	PhantomDstPort uint
 
+	TunnelCount   uint
+	V6            bool
 	ASN           uint     `json:",omitempty"`
 	CC            string   `json:",omitempty"`
-	V6            bool     `json:",omitempty"`
 	Transport     string   `json:",omitempty"`
 	Registrar     string   `json:",omitempty"`
 	TransportOpts []string `json:",omitempty"`
 	RegOpts       []string `json:",omitempty"`
-	TunnelCount   uint     `json:",omitempty"`
 	Tags          []string `json:",omitempty"`
 }
 

--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -119,6 +119,10 @@ func halfPipe(src net.Conn, dst net.Conn,
 				Stat().AddBytesDown(int64(nw))
 			}
 
+			if ew == nil && nw != nr {
+				ew = io.ErrShortWrite
+			}
+
 			if ew != nil {
 				if e := generalizeErr(ew); e != nil {
 					if isUpload {
@@ -129,10 +133,7 @@ func halfPipe(src net.Conn, dst net.Conn,
 				}
 				break
 			}
-			if nw != nr {
-				err = io.ErrShortWrite
-				break
-			}
+
 		}
 		if er != nil {
 			if e := generalizeErr(er); e != nil {
@@ -287,10 +288,10 @@ type tunnelStats struct {
 
 	TunnelCount   uint
 	V6            bool
-	ASN           uint     `json:",omitempty"`
-	CC            string   `json:",omitempty"`
-	Transport     string   `json:",omitempty"`
-	Registrar     string   `json:",omitempty"`
+	ASN           uint   `json:",omitempty"`
+	CC            string `json:",omitempty"`
+	Transport     string `json:",omitempty"`
+	Registrar     string `json:",omitempty"`
 	LibVer        uint
 	Gen           uint
 	TransportOpts []string `json:",omitempty"`

--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -45,7 +45,7 @@ func generalizeErr(err error) error {
 		return errConnRefused
 	} else if errors.Is(err, syscall.ECONNABORTED) {
 		return errConnAborted
-	} else if errN, ok := err.(net.Error); ok && !errN.Timeout() {
+	} else if errN, ok := err.(net.Error); ok && errN.Timeout() {
 		return errConnTimeout
 	}
 

--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -37,6 +37,8 @@ func generalizeErr(err error) error {
 		return nil
 	} else if errors.Is(err, net.ErrClosed) {
 		return nil
+	} else if errors.Is(err, io.EOF) {
+		return nil
 	} else if errors.Is(err, syscall.ECONNRESET) {
 		return errConnReset
 	} else if errors.Is(err, syscall.ECONNREFUSED) {
@@ -108,11 +110,11 @@ func halfPipe(src net.Conn, dst net.Conn,
 			}
 
 			if ew != nil {
-				if ew != io.EOF {
+				if e := generalizeErr(ew); e != nil {
 					if isUpload {
-						stats.CovertConnErr = generalizeErr(ew).Error()
+						stats.CovertConnErr = e.Error()
 					} else {
-						stats.ClientConnErr = generalizeErr(ew).Error()
+						stats.ClientConnErr = e.Error()
 					}
 				}
 				break
@@ -123,11 +125,11 @@ func halfPipe(src net.Conn, dst net.Conn,
 			}
 		}
 		if er != nil {
-			if er != io.EOF {
+			if e := generalizeErr(er); e != nil {
 				if isUpload {
-					stats.ClientConnErr = generalizeErr(er).Error()
+					stats.ClientConnErr = e.Error()
 				} else {
-					stats.CovertConnErr = generalizeErr(er).Error()
+					stats.CovertConnErr = e.Error()
 				}
 			}
 			break

--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -212,6 +212,8 @@ func Proxy(reg *DecoyRegistration, clientConn net.Conn, logger *log.Logger) {
 		Transport:   reg.Transport.String(),
 		Registrar:   reg.RegistrationSource.String(),
 		V6:          reg.PhantomIp.To4() == nil,
+		LibVer:      uint(reg.clientLibVer),
+		Gen:         uint(reg.DecoyListVersion),
 	}
 
 	covertConn, err := net.Dial("tcp", reg.Covert)
@@ -289,6 +291,8 @@ type tunnelStats struct {
 	CC            string   `json:",omitempty"`
 	Transport     string   `json:",omitempty"`
 	Registrar     string   `json:",omitempty"`
+	LibVer        uint
+	Gen           uint
 	TransportOpts []string `json:",omitempty"`
 	RegOpts       []string `json:",omitempty"`
 	Tags          []string `json:",omitempty"`

--- a/application/lib/proxies_test.go
+++ b/application/lib/proxies_test.go
@@ -61,8 +61,8 @@ func TestProxyMockCovertReset(t *testing.T) {
 	}
 
 	wg.Add(2)
-	go halfPipe(clientConn, covertConn, wg, oncePrintErr, logger, "Up "+"ABCDEF")
-	go halfPipe(covertConn, clientConn, wg, oncePrintErr, logger, "Down "+"ABCDEF")
+	go halfPipe(clientConn, covertConn, wg, oncePrintErr, logger, "Up "+"ABCDEF", &tunnelStats{proxyStats: getProxyStats()})
+	go halfPipe(covertConn, clientConn, wg, oncePrintErr, logger, "Down "+"ABCDEF", &tunnelStats{proxyStats: getProxyStats()})
 
 	wg.Wait()
 }
@@ -133,8 +133,8 @@ func TestHalfpipeDeadlineEcho(t *testing.T) {
 	oncePrintErr := sync.Once{}
 	wg.Add(2)
 
-	go halfPipe(clientStation, stationCovert, &wg, &oncePrintErr, logger, "Up "+"XXXXXX")
-	go halfPipe(stationCovert, clientStation, &wg, &oncePrintErr, logger, "Down "+"XXXXXX")
+	go halfPipe(clientStation, stationCovert, &wg, &oncePrintErr, logger, "Up "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
+	go halfPipe(stationCovert, clientStation, &wg, &oncePrintErr, logger, "Down "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
 
 	go func() {
 		defer covertCovert.Close()
@@ -182,8 +182,8 @@ func TestHalfpipeDeadlineUpload(t *testing.T) {
 	oncePrintErr := sync.Once{}
 	wg.Add(2)
 
-	go halfPipe(clientStation, stationCovert, &wg, &oncePrintErr, logger, "Up "+"XXXXXX")
-	go halfPipe(stationCovert, clientStation, &wg, &oncePrintErr, logger, "Down "+"XXXXXX")
+	go halfPipe(clientStation, stationCovert, &wg, &oncePrintErr, logger, "Up "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
+	go halfPipe(stationCovert, clientStation, &wg, &oncePrintErr, logger, "Down "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
 
 	go func() {
 		defer covertCovert.Close()
@@ -227,8 +227,8 @@ func TestHalfpipeDeadlineActual(t *testing.T) {
 	oncePrintErr := sync.Once{}
 	wg.Add(2)
 
-	go halfPipe(clientStation, stationCovert, &wg, &oncePrintErr, logger, "Up "+"XXXXXX")
-	go halfPipe(stationCovert, clientStation, &wg, &oncePrintErr, logger, "Down "+"XXXXXX")
+	go halfPipe(clientStation, stationCovert, &wg, &oncePrintErr, logger, "Up "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
+	go halfPipe(stationCovert, clientStation, &wg, &oncePrintErr, logger, "Down "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
 
 	var serverErr error
 	go func() {

--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -670,14 +670,14 @@ type regExpireLogMsg struct {
 	Reg2expire     int64
 	RegCount       int32
 
-	ASN           uint     `json:",omitempty"`
-	CC            string   `json:",omitempty"`
-	V6            bool     `json:",omitempty"`
+	ASN           uint   `json:",omitempty"`
+	CC            string `json:",omitempty"`
+	V6            bool
 	Transport     string   `json:",omitempty"`
 	Registrar     string   `json:",omitempty"`
 	TransportOpts []string `json:",omitempty"`
 	RegOpts       []string `json:",omitempty"`
-	TunnelCount   uint     `json:",omitempty"`
+	TunnelCount   uint
 	Tags          []string `json:",omitempty"`
 }
 

--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -765,13 +765,11 @@ func (r *RegisteredDecoys) removeOldRegistrations(logger *log.Logger) (int, int)
 
 		stats := r.removeRegistration(idx)
 		if stats != nil {
-			statsStr, _ := json.Marshal(stats)
 			if stats.Valid {
 				expiredValid++
-				logger.Infof("expired reg %s", statsStr)
-			} else {
-				logger.Debugf("expired reg %s", statsStr)
 			}
+			statsStr, _ := json.Marshal(stats)
+			logger.Debugf("expired reg %s", statsStr)
 		}
 	}
 

--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -670,15 +670,15 @@ type regExpireLogMsg struct {
 	Reg2expire     int64
 	RegCount       int32
 
-	ASN           uint
-	CC            string
-	V6            bool
-	Transport     string
-	Registrar     string
-	TransportOpts []string
-	RegOpts       []string
-	TunnelCount   uint
-	Tags          []string
+	ASN           uint     `json:",omitempty"`
+	CC            string   `json:",omitempty"`
+	V6            bool     `json:",omitempty"`
+	Transport     string   `json:",omitempty"`
+	Registrar     string   `json:",omitempty"`
+	TransportOpts []string `json:",omitempty"`
+	RegOpts       []string `json:",omitempty"`
+	TunnelCount   uint     `json:",omitempty"`
+	Tags          []string `json:",omitempty"`
 }
 
 func (r *RegisteredDecoys) getExpiredRegistrations() []string {

--- a/application/lib/registration_config.go
+++ b/application/lib/registration_config.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/refraction-networking/conjure/application/geoip"
 	"github.com/refraction-networking/conjure/application/liveness"
 )
 
@@ -12,6 +13,7 @@ import (
 // registrations lifecycle (ingest, validity, and eviction).
 type RegConfig struct {
 	*liveness.Config
+	*geoip.DBConfig
 
 	// number of worker threads for ingesting incoming registrations.
 	IngestWorkerCount int `toml:"ingest_worker_count"`

--- a/application/lib/registration_ingest.go
+++ b/application/lib/registration_ingest.go
@@ -374,6 +374,7 @@ func (rm *RegistrationManager) NewRegistration(c2s *pb.ClientToStation, conjureK
 		RegistrationSource: registrationSource,
 		RegistrationTime:   time.Now(),
 		regCount:           0,
+		tunnelCount:        0,
 	}
 
 	return &reg, nil

--- a/application/lib/registration_ingest.go
+++ b/application/lib/registration_ingest.go
@@ -279,7 +279,7 @@ func (rm *RegistrationManager) parseRegMessage(msg []byte) ([]*DecoyRegistration
 		return nil, err
 	}
 
-	// if either addres is not provided (reg came over api / client ip
+	// if either address is not provided (reg came over api / client ip
 	// logging disabled) fill with zeros to avoid nil dereference.
 	if parsed.GetRegistrationAddress() == nil {
 		parsed.RegistrationAddress = make([]byte, 16)
@@ -365,8 +365,8 @@ func (rm *RegistrationManager) NewRegistration(c2s *pb.ClientToStation, conjureK
 		TransportParams:  transportParams,
 		Flags:            c2s.Flags,
 
-		PhantomIp:   phantomAddr,
-		PhantomPort: phantomPort,
+		PhantomIp:    phantomAddr,
+		PhantomPort:  phantomPort,
 		PhantomProto: phantomProto,
 
 		Mask: c2s.GetMaskedDecoyServerName(),
@@ -406,6 +406,14 @@ func (rm *RegistrationManager) NewRegistrationC2SWrapper(c2sw *pb.C2SWrapper, in
 	}
 
 	reg.registrationAddr = clientAddr
+	reg.regCC, err = rm.GeoIP.CC(reg.registrationAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed geoip cc lookup: %w", err)
+	}
+	reg.regASN, err = rm.GeoIP.ASN(reg.registrationAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed geoip asn lookup: %w", err)
+	}
 
 	return reg, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/golang-lru v0.6.0
 	github.com/mroth/weightedrand v1.0.0
+	github.com/oschwald/geoip2-golang v1.8.0
 	github.com/pebbe/zmq4 v1.2.9
 	github.com/pelletier/go-toml v1.9.5
 	github.com/refraction-networking/gotapdance v1.3.5-0.20230118171142-e3cad8ff1431
@@ -32,7 +33,6 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/flynn/noise v1.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/oschwald/geoip2-golang v1.8.0 // indirect
 	github.com/oschwald/maxminddb-golang v1.10.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gitlab.com/yawning/edwards25519-extra.git v0.0.0-20211229043746-2f91fcc9fbdb // indirect

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,8 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/flynn/noise v1.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/oschwald/geoip2-golang v1.8.0 // indirect
+	github.com/oschwald/maxminddb-golang v1.10.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gitlab.com/yawning/edwards25519-extra.git v0.0.0-20211229043746-2f91fcc9fbdb // indirect
 	golang.org/x/sys v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,10 @@ github.com/mroth/weightedrand v1.0.0/go.mod h1:3p2SIcC8al1YMzGhAIoXD+r9olo/g/cdJ
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
+github.com/oschwald/geoip2-golang v1.8.0 h1:KfjYB8ojCEn/QLqsDU0AzrJ3R5Qa9vFlx3z6SLNcKTs=
+github.com/oschwald/geoip2-golang v1.8.0/go.mod h1:R7bRvYjOeaoenAp9sKRS8GX5bJWcZ0laWO5+DauEktw=
+github.com/oschwald/maxminddb-golang v1.10.0 h1:Xp1u0ZhqkSuopaKmk1WwHtjF0H9Hd9181uj2MQ5Vndg=
+github.com/oschwald/maxminddb-golang v1.10.0/go.mod h1:Y2ELenReaLAZ0b400URyGwvYxHV1dLIxBuyOsyYjHK0=
 github.com/pebbe/zmq4 v1.2.9 h1:JlHcdgq6zpppNR1tH0wXJq0XK03pRUc4lBlHTD7aj/4=
 github.com/pebbe/zmq4 v1.2.9/go.mod h1:nqnPueOapVhE2wItZ0uOErngczsJdLOGkebMxaO8r48=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=


### PR DESCRIPTION
In order to better understand the state of proxy tunnels this PR adds geoip information to event stats for specific events without logging client IP addresses. 

Client Geoip info (country code and ASN) has been added to the Proxy tunnel close log messages and the registration expire message. The registration expire message has been demoted to `debug` error level because it is not a very useful metric. 

Geoip lookup is implemented using MaxMind ASN and Country databases and config parameters for the paths to the databases are now available in the `application/config.toml`. If no path is provided then an `EmptyDatabase` is used which always returns `0` for ASN and `""` for countrycode which should be ommitted from the json log message. The paths are configured to be reloadable with the `SIGHUP` signal.

Log messages are json formatted so that we don't have to change logstash parsing to add new fields.

- [x] config paths in `application/config.toml`
- [x] disable if paths are left empty or missing
- [x] configuration reload using signaling
- [x] geoip lookup during registration ingest
- [x] printing event stats
  - [x] Proxy close event stats
  - [x] ~~registration expire stats (as debug level event stats)~~

Registration expire stats removed for now. Everything they were providing can be compressed into aggregate stats in a future PR reducing the number of lines logged total. For now it has been changed to a debug log line.

[Maxmind db auto-update](https://dev.maxmind.com/geoip/updating-databases?lang=en)