### PR TITLE
Proxy timeout error tracking

### DIFF
--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -162,7 +162,10 @@ func halfPipe(src net.Conn, dst net.Conn,
 	// Close dst
 	errDst := dst.Close()
 	if err = generalizeErr(errDst); err != nil {
-		if isUpload {
+		if errors.Is(err, errConnTimeout) {
+			stats.CovertConnErr = err.Error()
+			stats.ClientConnErr = err.Error()
+		} else if isUpload {
 			if stats.CovertConnErr == "" {
 				stats.CovertConnErr = err.Error()
 			}
@@ -176,7 +179,10 @@ func halfPipe(src net.Conn, dst net.Conn,
 	// Close src
 	errSrc := src.Close()
 	if err = generalizeErr(errSrc); err != nil {
-		if isUpload {
+		if errors.Is(err, errConnTimeout) {
+			stats.CovertConnErr = err.Error()
+			stats.ClientConnErr = err.Error()
+		} else if isUpload {
 			if stats.ClientConnErr == "" {
 				stats.ClientConnErr = err.Error()
 			}


### PR DESCRIPTION
timeouts assigned to both covert and client conns for stats tracking purposes because there is effectively a race condition determining which of the two linked conns will timeout first. We count this as a timeout for both connections as golang cant actually tell us which side is still live / retransmitting and such.  

From golang's perspective silence is bidirectional since we don't see acks / retransmits