### PR TITLE
Optimize registration payload size for DNS registrar

### DIFF
--- a/application/transports/anypb_nourl.go
+++ b/application/transports/anypb_nourl.go
@@ -1,0 +1,22 @@
+package transports
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// UnmarshalAnypbTo unmarshals the src anypb to dst without reading the src type url.
+// Used to unmarshal TransportParams in the registration message for saving space from
+// the type url so that the registration payload is small enough for the DNS registrar.
+func UnmarshalAnypbTo(src *anypb.Any, dst protoreflect.ProtoMessage) error {
+	expected, err := anypb.New(dst)
+	if err != nil {
+		return fmt.Errorf("error reading src type: %v", err)
+	}
+
+	src.TypeUrl = expected.TypeUrl
+	return anypb.UnmarshalTo(src, dst, proto.UnmarshalOptions{})
+}

--- a/application/transports/anypb_nourl.go
+++ b/application/transports/anypb_nourl.go
@@ -17,6 +17,10 @@ func UnmarshalAnypbTo(src *anypb.Any, dst protoreflect.ProtoMessage) error {
 		return fmt.Errorf("error reading src type: %v", err)
 	}
 
+	if src.TypeUrl != "" && src.TypeUrl != expected.TypeUrl {
+		return fmt.Errorf("incorrect non-empty TypeUrl: %v != %v", src.TypeUrl, expected.TypeUrl)
+	}
+
 	src.TypeUrl = expected.TypeUrl
 	return anypb.UnmarshalTo(src, dst, proto.UnmarshalOptions{})
 }

--- a/application/transports/anypb_nourl_test.go
+++ b/application/transports/anypb_nourl_test.go
@@ -44,6 +44,7 @@ func TestWrongType(t *testing.T) {
 
 func TestGarbage(t *testing.T) {
 	src, err := anypb.New(&pb.GenericTransportParams{RandomizeDstPort: proto.Bool(true)})
+	require.Nil(t, err)
 	garbagebytes, err := proto.Marshal(src)
 	require.Nil(t, err)
 	_, err = rand.Read(garbagebytes)

--- a/application/transports/anypb_nourl_test.go
+++ b/application/transports/anypb_nourl_test.go
@@ -1,0 +1,22 @@
+package transports_test
+
+import (
+	"testing"
+
+	"github.com/refraction-networking/conjure/application/transports"
+	pb "github.com/refraction-networking/gotapdance/protobuf"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func TestUnmarshall(t *testing.T) {
+	src, err := anypb.New(&pb.GenericTransportParams{RandomizeDstPort: proto.Bool(true)})
+	require.Nil(t, err)
+
+	dst := &pb.GenericTransportParams{}
+	err = transports.UnmarshalAnypbTo(src, dst)
+	require.Nil(t, err)
+
+	require.True(t, dst.GetRandomizeDstPort())
+}

--- a/application/transports/anypb_nourl_test.go
+++ b/application/transports/anypb_nourl_test.go
@@ -1,7 +1,9 @@
 package transports_test
 
 import (
+	"math/rand"
 	"testing"
+	"unsafe"
 
 	"github.com/refraction-networking/conjure/application/transports"
 	pb "github.com/refraction-networking/gotapdance/protobuf"
@@ -20,4 +22,41 @@ func TestUnmarshall(t *testing.T) {
 	require.Nil(t, err)
 
 	require.True(t, dst.GetRandomizeDstPort())
+}
+
+func TestMissingTypeURL(t *testing.T) {
+	src, err := anypb.New(&pb.GenericTransportParams{RandomizeDstPort: proto.Bool(true)})
+	require.Nil(t, err)
+	src.TypeUrl = ""
+
+	dst := &pb.GenericTransportParams{}
+	err = anypb.UnmarshalTo(src, dst, proto.UnmarshalOptions{})
+	require.NotNil(t, err)
+}
+
+func TestWrongType(t *testing.T) {
+	src, err := anypb.New(&pb.ClientToStation{Padding: []byte{0, 1}})
+	require.Nil(t, err)
+
+	dst := &pb.GenericTransportParams{}
+	err = transports.UnmarshalAnypbTo(src, dst)
+	require.Nil(t, err)
+
+	require.False(t, dst.GetRandomizeDstPort())
+}
+
+func TestGarbage(t *testing.T) {
+	src, err := anypb.New(&pb.ClientToStation{Padding: []byte{0, 1}})
+	require.Nil(t, err)
+	ptr := unsafe.Pointer(src)
+
+	for i := 0; i < int(unsafe.Sizeof(*src)); i++ {
+		*(*int)(ptr) = rand.Int()
+	}
+
+	dst := &pb.GenericTransportParams{}
+	err = transports.UnmarshalAnypbTo(src, dst)
+	require.Nil(t, err)
+
+	require.False(t, dst.GetRandomizeDstPort())
 }

--- a/application/transports/anypb_nourl_test.go
+++ b/application/transports/anypb_nourl_test.go
@@ -13,6 +13,7 @@ import (
 func TestUnmarshall(t *testing.T) {
 	src, err := anypb.New(&pb.GenericTransportParams{RandomizeDstPort: proto.Bool(true)})
 	require.Nil(t, err)
+	src.TypeUrl = ""
 
 	dst := &pb.GenericTransportParams{}
 	err = transports.UnmarshalAnypbTo(src, dst)

--- a/application/transports/wrapping/min/min.go
+++ b/application/transports/wrapping/min/min.go
@@ -8,7 +8,6 @@ import (
 	dd "github.com/refraction-networking/conjure/application/lib"
 	"github.com/refraction-networking/conjure/application/transports"
 	pb "github.com/refraction-networking/gotapdance/protobuf"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -65,7 +64,7 @@ func (Transport) ParseParams(libVersion uint, data *anypb.Any) (any, error) {
 	}
 
 	var m = &pb.GenericTransportParams{}
-	err := anypb.UnmarshalTo(data, m, proto.UnmarshalOptions{})
+	err := transports.UnmarshalAnypbTo(data, m)
 	return m, err
 }
 

--- a/application/transports/wrapping/obfs4/obfs4.go
+++ b/application/transports/wrapping/obfs4/obfs4.go
@@ -12,7 +12,6 @@ import (
 	"gitlab.com/yawning/obfs4.git/common/drbg"
 	"gitlab.com/yawning/obfs4.git/common/ntor"
 	"gitlab.com/yawning/obfs4.git/transports/obfs4"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -62,7 +61,7 @@ func (Transport) ParseParams(libVersion uint, data *anypb.Any) (any, error) {
 	}
 
 	var m = &pb.GenericTransportParams{}
-	err := anypb.UnmarshalTo(data, m, proto.UnmarshalOptions{})
+	err := transports.UnmarshalAnypbTo(data, m)
 	return m, err
 }
 


### PR DESCRIPTION
Protobuf changes in refraction-networking/gotapdance#110 made registration payload too large for the DNS registrar to handle. In refraction-networking/gotapdance#108 we use a workaround by removing the `TypeUrl` in the added `TransportParams` anypb, since we already know the type for each transport. Add the `TypeUrl` back upon receiving the `TransportParams` for anypb to unmarshal. 