### PR TITLE
Add Connection Tag Obfuscation Options

### DIFF
--- a/application/transports/obfuscate.go
+++ b/application/transports/obfuscate.go
@@ -76,7 +76,7 @@ func (GCMObfuscator) Obfuscate(plainText []byte, stationPubkey []byte) ([]byte, 
 	}
 	var clientPrivate, clientPublic, representative [32]byte
 	var sharedSecret []byte
-	for ok := false; ok != true; {
+	for ok := false; !ok; {
 		var sliceKeyPrivate []byte = clientPrivate[:]
 		_, err := rand.Read(sliceKeyPrivate)
 		if err != nil {
@@ -161,7 +161,7 @@ func (CTRObfuscator) Obfuscate(plainText []byte, stationPubkey []byte) ([]byte, 
 	}
 	var clientPrivate, clientPublic, representative [32]byte
 	var sharedSecret []byte
-	for ok := false; ok != true; {
+	for ok := false; !ok; {
 		var sliceKeyPrivate []byte = clientPrivate[:]
 		_, err := rand.Read(sliceKeyPrivate)
 		if err != nil {

--- a/application/transports/obfuscate.go
+++ b/application/transports/obfuscate.go
@@ -37,7 +37,7 @@ func (GCMObfuscator) TryReveal(ciphertext []byte, privateKey [32]byte) ([]byte, 
 
 	var representative, clientPubkey [32]byte
 	copy(representative[:], ciphertext[:32])
-	representative[31] &= 0x7F
+	representative[31] &= 0x3F
 	extra25519.RepresentativeToPublicKey(&clientPubkey, &representative)
 
 	sharedSecret, err := curve25519.X25519(privateKey[:], clientPubkey[:])
@@ -99,7 +99,7 @@ func (GCMObfuscator) Obfuscate(plainText []byte, stationPubkey []byte) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
-	representative[31] |= (0x80 & randByte[0])
+	representative[31] |= (0xC0 & randByte[0])
 
 	tagBuf := new(bytes.Buffer) // What we have to encrypt with the shared secret using AES
 	tagBuf.Write(representative[:])
@@ -132,7 +132,7 @@ func (CTRObfuscator) TryReveal(ciphertext []byte, privateKey [32]byte) ([]byte, 
 
 	var representative, clientPubkey [32]byte
 	copy(representative[:], ciphertext[:32])
-	representative[31] &= 0x7F
+	representative[31] &= 0x3F
 	extra25519.RepresentativeToPublicKey(&clientPubkey, &representative)
 
 	sharedSecret, err := curve25519.X25519(privateKey[:], clientPubkey[:])
@@ -184,7 +184,7 @@ func (CTRObfuscator) Obfuscate(plainText []byte, stationPubkey []byte) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
-	representative[31] |= (0x80 & randByte[0])
+	representative[31] |= (0xC0 & randByte[0])
 
 	tagBuf := new(bytes.Buffer) // What we have to encrypt with the shared secret using AES
 	tagBuf.Write(representative[:])

--- a/application/transports/obfuscate.go
+++ b/application/transports/obfuscate.go
@@ -1,0 +1,247 @@
+package transports
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/refraction-networking/gotapdance/ed25519/extra25519"
+	"golang.org/x/crypto/curve25519"
+)
+
+// Obfuscator provides an interface for obfuscating the tags that are sent by transports in order to
+// indicate their knowledge of the shared secret to the station.
+type Obfuscator interface {
+	// Take the plain text and perform an obfuscation to make it distinguishable to the station
+	Obfuscate(plaintext []byte, stationPubkey []byte) ([]byte, error)
+
+	// Take a cipher text and de-obfuscate to make it usable by the station
+	TryReveal(cipherText []byte, privateKey [32]byte) ([]byte, error)
+}
+
+// GCMObfuscator implements the Obfuscator interface using ECDHE and AES GCM. Prevents tag re-use.
+type GCMObfuscator struct{}
+
+// TryReveal for GCMObfuscator expects a ciphertext object where the first 32 bytes is an elligator
+// encoded public key with which the server can derive an ECDHE shared secret. This secret is then
+// used to decrypt and authenticate the remainder of the plaintext using AES GCM.
+func (GCMObfuscator) TryReveal(ciphertext []byte, privateKey [32]byte) ([]byte, error) {
+	if len(ciphertext) < 48 {
+		return nil, ErrPublicKeyLen
+	}
+
+	var representative, clientPubkey [32]byte
+	copy(representative[:], ciphertext[:32])
+	representative[31] &= 0x7F
+	extra25519.RepresentativeToPublicKey(&clientPubkey, &representative)
+
+	sharedSecret, err := curve25519.X25519(privateKey[:], clientPubkey[:])
+	if err != nil {
+		return nil, err
+	}
+
+	stationPubkeyHash := sha256.Sum256(sharedSecret[:])
+	aesKey := stationPubkeyHash[:16]
+	aesIvTag := stationPubkeyHash[16:28]
+
+	block, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return nil, err
+	}
+	// return block.Decrypt(nil, aesIvTag, cipherText[32:])
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	return aesgcm.Open(nil, aesIvTag, ciphertext[32:], nil)
+}
+
+// Obfuscate for GCMObfuscator derives a shared key using ECDHE an then encrypts the plaintext under
+// that key using AES GCM. The elligator representative for the clients public key is prepended
+// to the returned byte array. This means that the result length will likely be:
+//
+//	32 + len(plaintext) + 16
+//
+// [elligator encoded client Pub][Ciphertext + Auth tag]
+func (GCMObfuscator) Obfuscate(plainText []byte, stationPubkey []byte) ([]byte, error) {
+	if len(stationPubkey) != 32 {
+		return nil, fmt.Errorf("%w, received: %d", ErrPublicKeyLen, len(stationPubkey))
+	}
+	var clientPrivate, clientPublic, representative [32]byte
+	var sharedSecret []byte
+	for ok := false; ok != true; {
+		var sliceKeyPrivate []byte = clientPrivate[:]
+		_, err := rand.Read(sliceKeyPrivate)
+		if err != nil {
+			return nil, err
+		}
+
+		ok = extra25519.ScalarBaseMult(&clientPublic, &representative, &clientPrivate)
+	}
+
+	sharedSecret, err := curve25519.X25519(clientPrivate[:], stationPubkey)
+	if err != nil {
+		return nil, err
+	}
+
+	// extra25519.ScalarBaseMult does not randomize most significant bit(sign of y_coord?)
+	// Other implementations of elligator may have up to 2 non-random bits.
+	// Here we randomize the bit, expecting it to be flipped back to 0 on station
+	randByte := make([]byte, 1)
+	_, err = rand.Read(randByte)
+	if err != nil {
+		return nil, err
+	}
+	representative[31] |= (0x80 & randByte[0])
+
+	tagBuf := new(bytes.Buffer) // What we have to encrypt with the shared secret using AES
+	tagBuf.Write(representative[:])
+
+	stationPubkeyHash := sha256.Sum256(sharedSecret[:])
+	aesKey := stationPubkeyHash[:16]
+	aesIvTag := stationPubkeyHash[16:28] // 12 bytes for plaintext nonce
+
+	cipherText, err := aesGcmEncrypt(plainText, aesKey, aesIvTag)
+	if err != nil {
+		return nil, err
+	}
+
+	tagBuf.Write(cipherText)
+	tag := tagBuf.Bytes()
+
+	return tag, nil
+}
+
+// CTRObfuscator implements the Obfuscator interface using ECDHE and AES CTR. Prevents tag re-use.
+type CTRObfuscator struct{}
+
+// TryReveal for CTRObfuscator expects a ciphertext object where the first 32 bytes is an elligator
+// encoded public key with which the server can derive an ECDHE shared secret. This secret is then
+// used to decrypt the remainder of the plaintext using AES CTR.
+func (CTRObfuscator) TryReveal(ciphertext []byte, privateKey [32]byte) ([]byte, error) {
+	if len(ciphertext) < 32 {
+		return nil, ErrPublicKeyLen
+	}
+
+	var representative, clientPubkey [32]byte
+	copy(representative[:], ciphertext[:32])
+	representative[31] &= 0x7F
+	extra25519.RepresentativeToPublicKey(&clientPubkey, &representative)
+
+	sharedSecret, err := curve25519.X25519(privateKey[:], clientPubkey[:])
+	if err != nil {
+		return nil, err
+	}
+
+	stationPubkeyHash := sha256.Sum256(sharedSecret[:])
+	aesKey := stationPubkeyHash[:16]
+	aesIvTag := stationPubkeyHash[16:32]
+
+	return aesCTR(ciphertext[32:], aesKey, aesIvTag)
+}
+
+// Obfuscate for CTRObfuscator derives a shared key using ECDHE an then encrypts the plaintext under
+// that key using AES CTR. The elligator representative for the clients public key is prepended
+// to the returned byte array. This means that the result length will likely be:
+//
+//	32 + len(plaintext)
+//
+// [elligator encoded client Pub][Ciphertext]
+func (CTRObfuscator) Obfuscate(plainText []byte, stationPubkey []byte) ([]byte, error) {
+	if len(stationPubkey) != 32 {
+		return nil, errors.New("Unexpected station pubkey length. Expected: 32." +
+			" Received: " + strconv.Itoa(len(stationPubkey)) + ".")
+	}
+	var clientPrivate, clientPublic, representative [32]byte
+	var sharedSecret []byte
+	for ok := false; ok != true; {
+		var sliceKeyPrivate []byte = clientPrivate[:]
+		_, err := rand.Read(sliceKeyPrivate)
+		if err != nil {
+			return nil, err
+		}
+
+		ok = extra25519.ScalarBaseMult(&clientPublic, &representative, &clientPrivate)
+	}
+
+	sharedSecret, err := curve25519.X25519(clientPrivate[:], stationPubkey)
+	if err != nil {
+		return nil, err
+	}
+
+	// extra25519.ScalarBaseMult does not randomize most significant bit(sign of y_coord?)
+	// Other implementations of elligator may have up to 2 non-random bits.
+	// Here we randomize the bit, expecting it to be flipped back to 0 on station
+	randByte := make([]byte, 1)
+	_, err = rand.Read(randByte)
+	if err != nil {
+		return nil, err
+	}
+	representative[31] |= (0x80 & randByte[0])
+
+	tagBuf := new(bytes.Buffer) // What we have to encrypt with the shared secret using AES
+	tagBuf.Write(representative[:])
+
+	stationPubkeyHash := sha256.Sum256(sharedSecret[:])
+	aesKey := stationPubkeyHash[:16]
+	aesIvTag := stationPubkeyHash[16:32] // 16 bytes for CTR IV
+
+	cipherText, err := aesCTR(plainText, aesKey, aesIvTag)
+	if err != nil {
+		return nil, err
+	}
+
+	tagBuf.Write(cipherText)
+	tag := tagBuf.Bytes()
+
+	return tag, nil
+}
+
+// NilObfuscator implements the Obfuscator interface for no modification the provided tag /
+// plaintext / ciphertext. Will NOT prevent tag re-use if a registration is re-used.
+type NilObfuscator struct{}
+
+// TryReveal for NilObfuscator just returns the provided ciphertext without modification
+func (NilObfuscator) TryReveal(cipherText []byte, privateKey [32]byte) ([]byte, error) {
+	return cipherText, nil
+}
+
+// Obfuscate for NilObfuscator just returns the provided plaintext without modification
+func (NilObfuscator) Obfuscate(plainText []byte, stationPubkey []byte) ([]byte, error) {
+	return plainText, nil
+}
+
+// The key argument should be the AES key, either 16 or 32 bytes
+// to select AES-128 or AES-256.
+func aesGcmEncrypt(plaintext []byte, key []byte, iv []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	aesGcmCipher, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return aesGcmCipher.Seal(nil, iv, plaintext, nil), nil
+}
+
+func aesCTR(in []byte, key []byte, iv []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]byte, len(in))
+	stream := cipher.NewCTR(block, iv)
+	stream.XORKeyStream(out, in)
+
+	return out, nil
+}

--- a/application/transports/obfuscate_test.go
+++ b/application/transports/obfuscate_test.go
@@ -1,0 +1,78 @@
+package transports
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+
+	"github.com/refraction-networking/gotapdance/ed25519"
+	"github.com/refraction-networking/gotapdance/ed25519/extra25519"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/curve25519"
+)
+
+func TestObfuscateRevealIntended(t *testing.T) {
+	_, private, _ := ed25519.GenerateKey(rand.Reader)
+
+	var curve25519Public, curve25519Private [32]byte
+	extra25519.PrivateKeyToCurve25519(&curve25519Private, private)
+	curve25519.ScalarBaseMult(&curve25519Public, &curve25519Private)
+
+	buf := make([]byte, 32)
+	_, err := rand.Read(buf)
+	require.Nil(t, err)
+
+	for _, Obfsc := range []Obfuscator{GCMObfuscator{}, CTRObfuscator{}, NilObfuscator{}} {
+		ciphertext, err := Obfsc.Obfuscate(buf, curve25519Public[:])
+		require.Nil(t, err)
+
+		plaintext, err := Obfsc.TryReveal(ciphertext, curve25519Private)
+		require.Nil(t, err)
+
+		require.NotEmpty(t, plaintext)
+		require.True(t, bytes.Equal(buf, plaintext))
+	}
+}
+
+func TestObfuscateReveal1B(t *testing.T) {
+	_, private, _ := ed25519.GenerateKey(rand.Reader)
+
+	var curve25519Public, curve25519Private [32]byte
+	extra25519.PrivateKeyToCurve25519(&curve25519Private, private)
+	curve25519.ScalarBaseMult(&curve25519Public, &curve25519Private)
+
+	for _, Obfsc := range []Obfuscator{GCMObfuscator{}, CTRObfuscator{}, NilObfuscator{}} {
+		ciphertext, err := Obfsc.Obfuscate([]byte{0xff}, curve25519Public[:])
+		require.Nil(t, err)
+
+		plaintext, err := Obfsc.TryReveal(ciphertext, curve25519Private)
+		require.Nil(t, err)
+
+		require.NotEmpty(t, plaintext)
+		// t.Log(len(ciphertext))
+		require.True(t, bytes.Equal([]byte{0xff}, plaintext))
+	}
+}
+
+func TestObfuscateReveal100B(t *testing.T) {
+	_, private, _ := ed25519.GenerateKey(rand.Reader)
+
+	var curve25519Public, curve25519Private [32]byte
+	extra25519.PrivateKeyToCurve25519(&curve25519Private, private)
+	curve25519.ScalarBaseMult(&curve25519Public, &curve25519Private)
+
+	buf := make([]byte, 100)
+	_, err := rand.Read(buf)
+	require.Nil(t, err)
+
+	for _, Obfsc := range []Obfuscator{GCMObfuscator{}, CTRObfuscator{}, NilObfuscator{}} {
+		ciphertext, err := Obfsc.Obfuscate(buf, curve25519Public[:])
+		require.Nil(t, err)
+
+		plaintext, err := Obfsc.TryReveal(ciphertext, curve25519Private)
+		require.Nil(t, err)
+
+		require.NotEmpty(t, plaintext)
+		require.True(t, bytes.Equal(buf, plaintext))
+	}
+}

--- a/application/transports/transports.go
+++ b/application/transports/transports.go
@@ -12,8 +12,7 @@ import (
 )
 
 var (
-	// ErrTryAgain is returned by transports when
-	// it is inconclusive with the current amount of data
+	// ErrTryAgain is returned by transports when it is inconclusive with the current amount of data
 	// whether the transport exists in the connection.
 	ErrTryAgain = errors.New("not enough information to determine transport")
 
@@ -22,11 +21,19 @@ var (
 	// contain this transport. The caller shouldn't retry
 	// with this transport.
 	ErrNotTransport = errors.New("connection does not contain transport")
+
+	// ErrTransportNotSupported is returned when a transport is unable to service one or more of the
+	// required functions because the clientLibVersion is to old and the transport is not backward
+	// compatible to that version.
+	ErrTransportNotSupported = errors.New("Transport not supported ")
+
+	// ErrPublicKeyLen is returned when the length of the provided public key is incorrect for
+	// ed25519.
+	ErrPublicKeyLen = errors.New("Unexpected station pubkey length. Expected: 32B")
 )
 
-// PrefixConn allows arbitrary readers to serve as the data source
-// of a net.Conn. This allows us to consume data from the socket
-// while later making it available again (for things like handshakes).
+// PrefixConn allows arbitrary readers to serve as the data source of a net.Conn. This allows us to
+// consume data from the socket while later making it available again (for things like handshakes).
 type PrefixConn struct {
 	net.Conn
 	r io.Reader


### PR DESCRIPTION
add optional methods to obfuscate session hmacID using ECDHE+AES

This is beneficial because currently when a registration is used more than once the same hmac-id will be sent for the prefix transport for all connection. This will be useful for future transport implementation.