### PR TITLE
re-enable zmq auth by adding missing line

### DIFF
--- a/application/lib/config.go
+++ b/application/lib/config.go
@@ -20,9 +20,10 @@ type Config struct {
 // variable.
 func ParseConfig() (*Config, error) {
 	var c Config
-	_, err := toml.DecodeFile(os.Getenv("CJ_STATION_CONFIG"), &c)
+	var envPath = os.Getenv("CJ_STATION_CONFIG")
+	_, err := toml.DecodeFile(envPath, &c)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load config: %v", err)
+		return nil, fmt.Errorf("failed to load config(%s): %v", envPath, err)
 	}
 
 	c.ParseBlocklists()

--- a/pkg/regprocessor/regprocessor.go
+++ b/pkg/regprocessor/regprocessor.go
@@ -63,6 +63,11 @@ func NewRegProcessor(zmqBindAddr string, zmqPort uint16, privkey string, authVer
 	zmq.AuthSetVerbose(authVerbose)
 	zmq.AuthAllow("*")
 	zmq.AuthCurveAdd("*", stationPublicKeys...)
+	err = zmq.AuthStart()
+	if err != nil {
+		return nil, ErrZmqAuthFail
+	}
+
 	err = sock.ServerAuthCurve("*", privkey)
 	if err != nil {
 		return nil, ErrZmqAuthFail


### PR DESCRIPTION
Auth error was introduced in the merged registration API. This corrects that error. Tests to come in a future commit ensuring this cannot happen again.