### PR TITLE
Anonymized Capture Tool Timeout

### DIFF
--- a/util/captool/Cargo.toml
+++ b/util/captool/Cargo.toml
@@ -13,7 +13,7 @@ ipnet = "2.7.2"
 threadpool = "1.8.1"
 pnet = "0.33.0"
 hmac = "0.12.1"
-sha2 = "*"
+sha2 = "0.10.6"
 rand = "0.8.5"
 pcap-file = "2.0.0"
 clap = { version = "4.2.2", features = ["derive"] }
@@ -21,6 +21,7 @@ signal-hook = "0.3.15"
 flate2 = "1.0.25"
 log = "0.4.17"
 simple_logger = "4.1.0"
+humantime = "2.1.0"
 
 [dev-dependencies]
 tempfile = "3.5.0"

--- a/util/captool/src/packet_handler.rs
+++ b/util/captool/src/packet_handler.rs
@@ -132,8 +132,6 @@ impl PacketHandler {
         src: IpAddr,
         dst: IpAddr,
     ) -> Result<SupplementalFields, PacketError> {
-        debug!("{src} -> {dst}");
-
         let direction = self.should_anonymize(src, dst);
         let ip_of_interest = match direction {
             AnonymizeTypes::None => Err(PacketError::Skip)?,
@@ -147,6 +145,7 @@ impl PacketHandler {
             .trunc();
 
         let country = self.get_cc(ip_of_interest)?;
+        debug!("{src} -> {dst}");
 
         Ok(SupplementalFields {
             cc: country,


### PR DESCRIPTION
This PR adds a timeout option to terminate captures. This is helpful if running the captures automatically using something like cron. 