### PR TITLE
Add Conntrack Timeout to `on-reboot.sh`

### DIFF
--- a/on-reboot.sh
+++ b/on-reboot.sh
@@ -38,6 +38,15 @@ else
     exit_msg "Unknown driver $PF_DRIVER"
 fi
 
+# this allows the conntrack table to keep track of connections where the client dissapears and
+# the station retransmits fins longer than the kernel will keep track of the connection. This
+# works for default timeout values on linux for ubuntu 20.04 and 22.04 (others untested).
+required_timeout=90
+nf_conntrack_tcp_timeout_last_ack=$(sysctl --values net.netfilter.nf_conntrack_tcp_timeout_last_ack)
+if [ "$nf_conntrack_tcp_timeout_last_ack" -lt "$required_timeout" ];then
+        sysctl -w net.netfilter.nf_conntrack_tcp_timeout_last_ack=90
+fi
+
 # Create a tunnel for each core.
 # The tunnel numbers do not match the core index per the OS,
 # but instead match the count of cores being used by conjure.


### PR DESCRIPTION
This PR adds a simple sysctl check to on-reboot for conntrack timeout. For now I have only tested this on 20.04 and 22.04 for the default sysctl values relating to TCP timeout. 

If the tcp retransmission variables have been modified this may not work properly and you risk allowing outgoing packets with the real station IP instead of the spoofed phantom IP. A future iteration could directly access the tcp retransmission variables to ensure that there will be no race between retransmission and GC in the conntrack tables, but for now this is good enough (and I am not sure I understand the TCP failure flow where the client dissapears well enough to calculate this properly).