### PR TITLE
Maintenance updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ crate-type = ["rlib", "staticlib"]
 
 [dependencies]
 toml = "0.7"
-serde = "1.0"
-serde_derive = "1.0"
+serde = {version="1.0", features=["derive"]}
 libc = "0.2"
 aes-gcm = { version="0.10", features=["aes"]}
 chrono = "0.4"

--- a/rust_util.c
+++ b/rust_util.c
@@ -5,8 +5,8 @@
 #include <string.h>
 #include <unistd.h>
 
-void get_cpu_time(int64_t* usr_secs, int64_t* usr_micros,
-                  int64_t* sys_secs, int64_t* sys_micros)
+void get_cpu_time(int64_t *usr_secs, int64_t *usr_micros,
+                  int64_t *sys_secs, int64_t *sys_micros)
 {
     struct rusage usage;
     getrusage(RUSAGE_SELF, &usage);
@@ -16,14 +16,14 @@ void get_cpu_time(int64_t* usr_secs, int64_t* usr_micros,
     *sys_micros = usage.ru_stime.tv_usec;
 }
 
-extern void* g_rust_cli_conf_proto_ptr;
-const void* get_global_cli_conf()
+extern void *g_rust_cli_conf_proto_ptr;
+const void *get_global_cli_conf()
 {
     return g_rust_cli_conf_proto_ptr;
 }
 
-extern void* g_rust_failed_map;
-void* get_mut_global_failure_map()
+extern void *g_rust_failed_map;
+void *get_mut_global_failure_map()
 {
     return g_rust_failed_map;
 }
@@ -53,13 +53,14 @@ int try_open_reporter()
 
 void open_reporter(const char *fname)
 {
-    strncpy(REPORTER_FNAME, fname, sizeof(REPORTER_FNAME)-1);
+    strncpy(REPORTER_FNAME, fname, sizeof(REPORTER_FNAME) - 1);
     try_open_reporter();
 }
 
 size_t write_reporter(uint8_t *buf, size_t len)
 {
-    if (REPORTER_FD < 0 && try_open_reporter() < 0) {
+    if (REPORTER_FD < 0 && try_open_reporter() < 0)
+    {
         return 0;
     }
     ssize_t ret = write(REPORTER_FD, buf, len);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ extern crate rand;
 extern crate protobuf;
 extern crate redis;
 extern crate serde;
-extern crate serde_derive;
 extern crate toml;
 extern crate tuntap; // https://github.com/ewust/tuntap.rs
 extern crate zmq;
@@ -21,7 +20,7 @@ extern crate zmq;
 use std::mem::transmute;
 use util::precise_time_ns;
 
-use serde_derive::Deserialize;
+use serde::Deserialize;
 use std::env;
 use std::fs;
 


### PR DESCRIPTION
This PR fixes a serde usage issue that was breaking compile for serde `v1.0.130`  as well as a compile warning that has been around for a while about `strncpy` bounds.