### PR TITLE
Infrastructure fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ libtapdance/genkey
 cmd/registration-server/registration-server
 target
 bin/
+Cargo.lock

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ touch /opt/conjure/src/lib.rs
 PATH="$HOME/.cargo/bin:$PATH" make rust
 EOF
 
-RUN PATH="$HOME/.cargo/bin:$PATH" make conjure-sim && mv conjure conjure-sim
+RUN PATH="$HOME/.cargo/bin:$PATH" make conjure-sim && mv bin/conjure bin/conjure-sim
 RUN PATH="$HOME/.cargo/bin:$PATH" make conjure
 
 COPY go.* /opt/conjure/
@@ -66,11 +66,11 @@ RUN PATH="$HOME/.go/bin/:$PATH" make app
 RUN PATH="$HOME/.go/bin/:$PATH" make registration-server
 
 # Add default configs and launch scripts
-COPY sysconfig/ /opt/conjure/sysconfig
-COPY scripts/ /opt/conjure/bin
+COPY sysconfig/conjure.conf /opt/conjure/sysconfig/
+COPY scripts/ /opt/conjure/scripts
 
 # add application as default entrypoint for dev reasons.
-ENTRYPOINT /opt/conjure/application/application
+ENTRYPOINT /opt/conjure/scripts/start_application.sh
 
 
 # ------------------------------------------------------------------------------
@@ -78,75 +78,65 @@ ENTRYPOINT /opt/conjure/application/application
 # ------------------------------------------------------------------------------
 FROM base_pfring as conjure_zbalance
 # Add default configs and launch scripts
-COPY sysconfig/ /opt/conjure/sysconfig
-COPY scripts/ /opt/conjure/bin
+COPY sysconfig/conjure.conf /opt/conjure/sysconfig/
+COPY scripts/start_zbalance_ipc.sh /opt/conjure/scripts/
 
-ENTRYPOINT /opt/conjure/bin/start_zbalance_ipc.sh
-
+ENTRYPOINT /opt/conjure/scripts/start_zbalance_ipc.sh
 
 # ------------------------------------------------------------------------------
 # Production image detector only (kind of, requires pfring)
 # ------------------------------------------------------------------------------
 FROM base_pfring as conjure_det
 # Add default configs and launch scripts
-COPY sysconfig/ /opt/conjure/sysconfig
-COPY scripts/ /opt/conjure/bin
+COPY sysconfig/conjure.conf /opt/conjure/sysconfig
+COPY scripts/ /opt/conjure/scripts
 
 RUN apt update && apt install -yq libzmq3-dev
-COPY --from=dev_img /opt/conjure/conjure /opt/conjure/bin/
-
+COPY --from=dev_img /opt/conjure/bin/conjure /opt/conjure/bin/
 
 # ------------------------------------------------------------------------------
 # Production image application only
 # ------------------------------------------------------------------------------
 FROM ubuntu:20.04 as conjure_app
 # Add default configs and launch scripts
-COPY sysconfig/ /opt/conjure/sysconfig
-COPY scripts/ /opt/conjure/bin
-COPY application/ /opt/conjure/application
+COPY sysconfig/conjure.conf /opt/conjure/sysconfig/
+COPY scripts/ /opt/conjure/scripts
 
 RUN apt update && apt install -yq libzmq3-dev
-COPY --from=dev_img /opt/conjure/application/application /opt/conjure/bin/
-
+COPY --from=dev_img /opt/conjure/bin/application /opt/conjure/bin/
 
 # ------------------------------------------------------------------------------
 # Production image registration server only
 # ------------------------------------------------------------------------------
 FROM ubuntu:20.04 as conjure_reg
 # Add default configs and launch scripts
-COPY sysconfig/ /opt/conjure/sysconfig
-COPY scripts/ /opt/conjure/bin
+COPY sysconfig/conjure.conf /opt/conjure/sysconfig/
+COPY scripts/ /opt/conjure/scripts/
 
 RUN apt update && apt install -yq libzmq3-dev
-COPY --from=dev_img /opt/conjure/cmd/registration-server/registration-server /opt/conjure/bin/
-
+COPY --from=dev_img /opt/conjure/bin/registration-server /opt/conjure/bin/
 
 # ------------------------------------------------------------------------------
 # Simulation image (no pfring required)
 # ------------------------------------------------------------------------------
 FROM ubuntu:20.04 as conjure_sim
 # Add default configs and launch scripts
-COPY sysconfig/ /opt/conjure/sysconfig
-COPY scripts/ /opt/conjure/bin
+COPY sysconfig/conjure.conf /opt/conjure/sysconfig/
+COPY scripts/ /opt/conjure/scripts/
 
 RUN apt update && apt install -yq libzmq3-dev
-COPY --from=dev_img /opt/conjure/conjure-sim /opt/conjure/bin/conjure
-COPY --from=dev_img /opt/conjure/cmd/registration-server/registration-server /opt/conjure/bin/
-COPY --from=dev_img /opt/conjure/conjure /opt/conjure/bin/
-
+COPY --from=dev_img /opt/conjure/bin/conjure-sim /opt/conjure/bin/conjure
+COPY --from=dev_img /opt/conjure/bin/registration-server /opt/conjure/bin/
 
 # ------------------------------------------------------------------------------
 # Production image all (default)
 # ------------------------------------------------------------------------------
 FROM base_pfring as conjure
 # Add default configs and launch scripts
-COPY sysconfig/ /opt/conjure/sysconfig
-COPY scripts/ /opt/conjure/bin
-COPY application/ /opt/conjure/application
+COPY sysconfig/conjure.conf /opt/conjure/sysconfig/
+COPY scripts/ /opt/conjure/scripts/
 
 RUN apt update && apt install -yq libzmq3-dev
-COPY --from=dev_img /opt/conjure/application/application /opt/conjure/bin/
-COPY --from=dev_img /opt/conjure/cmd/registration-server/registration-server /opt/conjure/bin/
-COPY --from=dev_img /opt/conjure/conjure /opt/conjure/bin/
+COPY --from=dev_img /opt/conjure/bin/ /opt/conjure/bin/
 
 # ENTRYPOINT /bin/bash

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     logging:
       driver: "journald"
     restart: "always"
-    command: [ "/opt/conjure/bin/start_zbalance_ipc.sh" ]
+    command: [ "/opt/conjure/scripts/start_zbalance_ipc.sh" ]
 
   # # DEBUG PF_RING / zbalance
   #  zcount:
@@ -43,7 +43,7 @@ services:
       [
         "bash",
         "-c",
-        "sleep 10 && /opt/conjure/bin/start_detector.sh"
+        "sleep 10 && /opt/conjure/scripts/start_detector.sh"
       ]
 
   conjure-app:
@@ -59,5 +59,5 @@ services:
       [
         "bash",
         "-c",
-        "sleep 10 && /opt/conjure/bin/start_application.sh"
+        "sleep 10 && /opt/conjure/scripts/start_application.sh"
       ]

--- a/on-reboot.sh
+++ b/on-reboot.sh
@@ -113,11 +113,11 @@ if [[ -z "$rule_table_check" ]]; then
 fi
 
 build_or_rebuild_iptables nat CJ_PREROUTING
-do_or_die "iptables -t nat -A PREROUTING -j CJ_PREROUTING"
-do_or_die "ip6tables -t nat -A PREROUTING -j CJ_PREROUTING"
+do_or_die "iptables -t nat -I PREROUTING 1 -j CJ_PREROUTING"
+do_or_die "ip6tables -t nat -I PREROUTING 1 -j CJ_PREROUTING"
 build_or_rebuild_iptables filter CJ_INPUT
-do_or_die "iptables -A INPUT -j CJ_INPUT"
-do_or_die "ip6tables -A INPUT -j CJ_INPUT"
+do_or_die "iptables -I INPUT 1 -j CJ_INPUT"
+do_or_die "ip6tables -I INPUT 1 -j CJ_INPUT"
 
 # Create a tunnel for each core.
 # The tunnel numbers do not match the core index per the OS,

--- a/on-reboot.sh
+++ b/on-reboot.sh
@@ -34,7 +34,7 @@ build_or_rebuild_iptables() {
     return_code=$?
     if [ $return_code -eq 0 ]; then
         # Chain already exists
-        iptables -t $table -X ${chain}
+        iptables -t ${table} -X ${chain}
     fi
     iptables -t ${table} -N ${chain}
 
@@ -42,7 +42,7 @@ build_or_rebuild_iptables() {
     return_code=$?
     if [ $return_code -eq 0 ]; then
         # Chain already exists
-        ip6tables -t $table -X ${chain}
+        ip6tables -t ${table} -X ${chain}
     fi
     ip6tables -t ${table} -N ${chain}
 }
@@ -116,8 +116,8 @@ build_or_rebuild_iptables nat CJ_PREROUTING
 do_or_die "iptables -t nat -A PREROUTING -j CJ_PREROUTING"
 do_or_die "ip6tables -t nat -A PREROUTING -j CJ_PREROUTING"
 build_or_rebuild_iptables filter CJ_INPUT
-do_or_die "iptable -A INPUT -j CJ_INPUT"
-do_or_die "ip6table -A INPUT -j CJ_INPUT"
+do_or_die "iptables -A INPUT -j CJ_INPUT"
+do_or_die "ip6tables -A INPUT -j CJ_INPUT"
 
 # Create a tunnel for each core.
 # The tunnel numbers do not match the core index per the OS,

--- a/on-reboot.sh
+++ b/on-reboot.sh
@@ -3,7 +3,7 @@
 # Use this script once after reboot, and on configuration changes
 # that affect variables in the config file.
 # See README.md
-# Run as sud
+# Run as sudo
 
 # if conjure path is unset (not empty -- unset) use the default.
 if [ -z "${CJ_PATH+x}" ]; then
@@ -24,7 +24,62 @@ exit_msg() {
     exit 1
 }
 
-# Otherwise, this section will require constant updating.
+build_or_rebuild_iptables() {
+    if [[ $# -lt 2 ]]; then
+        exit_msg "script broken, build_or_rebuild requires iptables table and chain names"
+    fi
+    local chain=$1
+    local table=$2
+    iptables -n -L ${chain} >/dev/null 2>&
+    return_code=$?
+    if [ $return_code -eq 0 ]; then
+        # Chain already exists
+        iptables -t $table -X ${chain}
+    fi
+    iptables -t ${table} -N ${chain}
+
+    ip6tables -n -L ${chain} >/dev/null 2>&
+    return_code=$?
+    if [ $return_code -eq 0 ]; then
+        # Chain already exists
+        ip6tables -t $table -X ${chain}
+    fi
+    ip6tables -t ${table} -N ${chain}
+}
+
+tun_setup_fn () {
+    if [[ $# -lt 2 ]]; then
+        exit_msg "script broken, tun_setup requires tun id and ip table name"
+    fi
+
+    local N=$1
+    local table=$2
+    ip tuntap del mode tun tun${N}
+    do_or_die "ip tuntap add mode tun tun${N}"
+    do_or_die "sysctl -w net.ipv4.conf.tun${N}.rp_filter=0"
+
+    local rule_condition="iif tun${N} lookup ${table}"
+    # Check if the rule exists
+    local output=$(ip rule show | grep "$rule_condition")
+    if ! [[ -n "$output" ]]; then
+        # if not, add it
+        do_or_die "ip rule add iif tun${N} lookup ${table}"
+    fi
+
+    # not sure if we need to do rule below for every tun
+    # `RTNETLink answers: File exists` means the route is already there; harmless, but can we avoid it?
+    ip route add local 0.0.0.0/0 dev tun${N} table ${table}
+
+
+    do_or_die "iptables -t nat -I CJ_PREROUTING 1 -p tcp -i tun${N} -j DNAT --to ${IP4_ADDR}:41245"
+    do_or_die "iptables -t nat -I CJ_PREROUTING 1 -p udp -i tun${N} -j DNAT --to ${IP4_ADDR}:41245"
+    do_or_die "ip6tables -t nat -I CJ_PREROUTING 1 -p tcp -i tun${N} -j DNAT --to ${IP6_ADDR}:41245"
+    do_or_die "ip6tables -t nat -I CJ_PREROUTING 1 -p udp -i tun${N} -j DNAT --to ${IP6_ADDR}:41245"
+    do_or_die "iptables -I CJ_INPUT 1 -i tun${N} -j ACCEPT"
+    do_or_die "ip6tables -I CJ_INPUT 1 -i tun${N} -j ACCEPT"
+}
+
+
 if [ "x$PF_DRIVER" = "xe1000e" ]; then
     pf_ringcfg --configure-driver e1000e --rss-queues 1
     pf_ringcfg --list-interfaces
@@ -44,35 +99,34 @@ fi
 required_timeout=90
 nf_conntrack_tcp_timeout_last_ack=$(sysctl --values net.netfilter.nf_conntrack_tcp_timeout_last_ack)
 if [ "$nf_conntrack_tcp_timeout_last_ack" -lt "$required_timeout" ];then
-        sysctl -w net.netfilter.nf_conntrack_tcp_timeout_last_ack=90
+    sysctl -w net.netfilter.nf_conntrack_tcp_timeout_last_ack=90
 fi
+
+# Internal Network Setup
+do_or_die "sysctl -w net.ipv4.conf.default.rp_filter=0"
+
+rule_table_name="custom"
+rule_table_check=$(ip route show table "$rule_table_name")
+if [[ -z "$rule_table_check" ]]; then
+  echo "adding routing table ${rule_table_name}"
+  echo "200 ${rule_table_name}" >> /etc/iproute2/rt_tables
+fi
+
+build_or_rebuild_iptables nat CJ_PREROUTING
+do_or_die "iptables -t nat -A PREROUTING -j CJ_PREROUTING"
+do_or_die "ip6tables -t nat -A PREROUTING -j CJ_PREROUTING"
+build_or_rebuild_iptables filter CJ_INPUT
+do_or_die "iptable -A INPUT -j CJ_INPUT"
+do_or_die "ip6table -A INPUT -j CJ_INPUT"
 
 # Create a tunnel for each core.
 # The tunnel numbers do not match the core index per the OS,
 # but instead match the count of cores being used by conjure.
 echo "Setting up devices tun{${OFFSET}..$((OFFSET + CORE_COUNT -1 ))}, adding rules for them, and turning off RP filters."
-do_or_die "sysctl -w net.ipv4.conf.all.rp_filter=0"
-# Or maybe just set up for all of them instead?
 for CORE in `seq $OFFSET $((OFFSET + CORE_COUNT -1 ))`
 do
-    # echo "setting up tun${CORE} ${IP4_ADDR}, ${IP6_ADDR}"
-    ip tuntap del mode tun tun${CORE}
-    do_or_die "ip tuntap add mode tun tun${CORE}"
-    do_or_die "sysctl -w net.ipv4.conf.tun${CORE}.rp_filter=0"
-    do_or_die "ip rule add iif tun${CORE} lookup custom"
-
-    # not sure if we need to do rule below for every tun
-    # `RTNETLink answers: File exists` means the route is already there; harmless, but can we avoid it?
-    ip route add local 0.0.0.0/0 dev tun${CORE} table custom
-
-    do_or_die "iptables -t nat -I PREROUTING 1 -p tcp -i tun${CORE} -j DNAT --to ${IP4_ADDR}:41245"
-    do_or_die "iptables -t nat -I PREROUTING 1 -p udp -i tun${CORE} -j DNAT --to ${IP4_ADDR}:41245"
-    do_or_die "ip6tables -t nat -I PREROUTING 1 -p tcp -i tun${CORE} -j DNAT --to ${IP6_ADDR}:41245"
-    do_or_die "ip6tables -t nat -I PREROUTING 1 -p udp -i tun${CORE} -j DNAT --to ${IP6_ADDR}:41245"
-    do_or_die "iptables -I INPUT 1 -i tun${CORE} -j ACCEPT"
-    do_or_die "ip6tables -I INPUT 1 -i tun${CORE} -j ACCEPT"
+    tun_setup_fn ${CORE} ${rule_table_name}
 done
-
 
 echo "Setting up hugepages"
 if [ ! -d "/mnt/hugepages" ]; then

--- a/sysconfig/conjure-reg.service
+++ b/sysconfig/conjure-reg.service
@@ -4,7 +4,7 @@ Description=Conjure Registration Server
 [Service]
 Type=simple
 
-WorkingDirectory=/opt/conjure/cmd/registration-server/
+WorkingDirectory=/opt/conjure/
 
 SyslogIdentifier=conjure
 # EnvironmentFile=/opt/conjure/sysconfig/conjure.conf

--- a/sysconfig/zbalance.service
+++ b/sysconfig/zbalance.service
@@ -12,7 +12,7 @@ SyslogIdentifier=zbalance
 # EnvironmentFile=/opt/conjure/sysconfig/conjure.conf
 
 # makes if binary doesn't exist
-#ExecStartPre=/usr/bin/make zbalance
+ExecStartPre=/opt/conjure/bin/on-reboot.sh
 
 ExecStart=/bin/bash /opt/conjure/scripts/start_zbalance_ipc.sh
 


### PR DESCRIPTION
* fix error in `conjure-reg.service` around paths
* update `on-reboot.sh` to not infinitely add iptables rules.
  * use explicitly named rule chains
  * if you run `on-reboot.sh` and the chain already exists it will delete it and make it anew
* updated `zbalance.service` to run `on-reboot.sh` as an `ExecPrestart` to ensure that env is set up even on reboot.