### PR TITLE
Prefix Transport debugging fixes

### DIFF
--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -223,6 +223,11 @@ func Proxy(reg *DecoyRegistration, clientConn net.Conn, logger *log.Logger) {
 		Gen:         uint(reg.DecoyListVersion),
 	}
 
+	paramStrs := (*reg.TransportPtr).ParamStrings(reg.TransportParams)
+	if paramStrs != nil {
+		tunStats.TransportOpts = paramStrs
+	}
+
 	covertConn, err := net.Dial("tcp", reg.Covert)
 	if e := generalizeErr(err); e != nil {
 		tunStats.CovertDialErr = e.Error()

--- a/application/lib/registration.go
+++ b/application/lib/registration.go
@@ -272,6 +272,7 @@ type DecoyRegistration struct {
 	Covert, Mask       string
 	Flags              *pb.RegistrationFlags
 	Transport          pb.TransportType
+	TransportPtr       *Transport
 	TransportParams    any
 	RegistrationTime   time.Time
 	RegistrationSource *pb.RegistrationSource

--- a/application/lib/registration_ingest.go
+++ b/application/lib/registration_ingest.go
@@ -348,6 +348,11 @@ func (rm *RegistrationManager) NewRegistration(c2s *pb.ClientToStation, conjureK
 			err)
 	}
 
+	var transport, ok = rm.registeredDecoys.transports[c2s.GetTransport()]
+	if !ok {
+		return nil, fmt.Errorf("unknown transport")
+	}
+
 	transportParams, err := rm.getTransportParams(c2s.GetTransport(), c2s.GetTransportParams(), clientLibVer)
 	if err != nil {
 		return nil, fmt.Errorf("error handling transport params: %s", err)
@@ -368,6 +373,7 @@ func (rm *RegistrationManager) NewRegistration(c2s *pb.ClientToStation, conjureK
 		Keys:             conjureKeys,
 		Covert:           c2s.GetCovertAddress(),
 		Transport:        c2s.GetTransport(),
+		TransportPtr:     &transport,
 		TransportParams:  transportParams,
 		Flags:            c2s.Flags,
 

--- a/application/lib/transports.go
+++ b/application/lib/transports.go
@@ -38,6 +38,10 @@ type Transport interface {
 	// provided by the client during registration. The libVersion is provided incase of version
 	// dependent changes in the transport params or param parsing.
 	ParseParams(libVersion uint, data *anypb.Any) (any, error)
+
+	// ParamStrings returns an array of tag string that will be added to tunStats when a proxy
+	// session is closed.
+	ParamStrings(p any) []string
 }
 
 // WrappingTransport describes any transport that is able to passively

--- a/application/lib/transports_mock.go
+++ b/application/lib/transports_mock.go
@@ -56,6 +56,12 @@ func (*mockTransport) ParseParams(libVersion uint, data *anypb.Any) (any, error)
 	return m, err
 }
 
+// ParamStrings returns an array of tag string that will be added to tunStats when a proxy
+// session is closed. For now, no params of interest.
+func (m *mockTransport) ParamStrings(p any) []string {
+	return nil
+}
+
 // GetDstPort Given the library version, a seed, and a generic object
 // containing parameters the transport should be able to return the
 // destination port that a clients phantom connection will attempt to reach

--- a/application/transports/wrapping/min/client.go
+++ b/application/transports/wrapping/min/client.go
@@ -39,8 +39,8 @@ func (*ClientTransport) ID() pb.TransportType {
 
 // GetParams returns a generic protobuf with any parameters from both the registration and the
 // transport.
-func (t *ClientTransport) GetParams() proto.Message {
-	return t.Parameters
+func (t *ClientTransport) GetParams() (proto.Message, error) {
+	return t.Parameters, nil
 }
 
 // SetParams allows the caller to set parameters associated with the transport, returning an
@@ -56,7 +56,7 @@ func (t *ClientTransport) SetParams(p any) error {
 }
 
 // GetDstPort returns the destination port that the client should open the phantom connection to
-func (t *ClientTransport) GetDstPort(seed []byte, params any) (uint16, error) {
+func (t *ClientTransport) GetDstPort(seed []byte) (uint16, error) {
 	if t.Parameters == nil || !t.Parameters.GetRandomizeDstPort() {
 		return 443, nil
 	}

--- a/application/transports/wrapping/min/min.go
+++ b/application/transports/wrapping/min/min.go
@@ -69,6 +69,12 @@ func (Transport) ParseParams(libVersion uint, data *anypb.Any) (any, error) {
 	return m, err
 }
 
+// ParamStrings returns an array of tag string that will be added to tunStats when a proxy
+// session is closed. For now, no params of interest.
+func (t Transport) ParamStrings(p any) []string {
+	return nil
+}
+
 // WrapConnection attempts to wrap the given connection in the transport. It
 // takes the information gathered so far on the connection in data, attempts to
 // identify itself, and if it positively identifies itself wraps the connection

--- a/application/transports/wrapping/min/min_test.go
+++ b/application/transports/wrapping/min/min_test.go
@@ -24,7 +24,7 @@ func TestSuccessfulWrap(t *testing.T) {
 
 	var transport Transport
 	manager := tests.SetupRegistrationManager(tests.Transport{Index: pb.TransportType_Min, Transport: transport})
-	c2p, sfp, reg := tests.SetupPhantomConnections(manager, pb.TransportType_Min, 0)
+	c2p, sfp, reg := tests.SetupPhantomConnections(manager, pb.TransportType_Min, nil, 0)
 	defer c2p.Close()
 	defer sfp.Close()
 	require.NotNil(t, reg)
@@ -52,7 +52,7 @@ func TestSuccessfulWrap(t *testing.T) {
 func TestUnsuccessfulWrap(t *testing.T) {
 	var transport Transport
 	manager := tests.SetupRegistrationManager(tests.Transport{Index: pb.TransportType_Min, Transport: transport})
-	c2p, sfp, reg := tests.SetupPhantomConnections(manager, pb.TransportType_Min, 0)
+	c2p, sfp, reg := tests.SetupPhantomConnections(manager, pb.TransportType_Min, nil, 0)
 	defer c2p.Close()
 	defer sfp.Close()
 
@@ -76,7 +76,7 @@ func TestTryAgain(t *testing.T) {
 	var transport Transport
 	var err error
 	manager := tests.SetupRegistrationManager(tests.Transport{Index: pb.TransportType_Min, Transport: transport})
-	c2p, sfp, reg := tests.SetupPhantomConnections(manager, pb.TransportType_Min, 0)
+	c2p, sfp, reg := tests.SetupPhantomConnections(manager, pb.TransportType_Min, nil, 0)
 	defer c2p.Close()
 	defer sfp.Close()
 
@@ -119,13 +119,15 @@ func TestTryParamsToDstPort(t *testing.T) {
 		ct := ClientTransport{Parameters: &pb.GenericTransportParams{RandomizeDstPort: &testCase.r}}
 		var transport Transport
 
-		rawParams, err := anypb.New(ct.GetParams())
+		params, err := ct.GetParams()
+		require.Nil(t, err)
+		rawParams, err := anypb.New(params)
 		require.Nil(t, err)
 
-		params, err := transport.ParseParams(clv, rawParams)
+		newParams, err := transport.ParseParams(clv, rawParams)
 		require.Nil(t, err)
 
-		port, err := transport.GetDstPort(clv, seed, params)
+		port, err := transport.GetDstPort(clv, seed, newParams)
 		require.Nil(t, err)
 		require.Equal(t, testCase.p, port)
 	}

--- a/application/transports/wrapping/obfs4/client.go
+++ b/application/transports/wrapping/obfs4/client.go
@@ -39,8 +39,8 @@ func (*ClientTransport) ID() pb.TransportType {
 
 // GetParams returns a generic protobuf with any parameters from both the registration and the
 // transport.
-func (t *ClientTransport) GetParams() proto.Message {
-	return t.Parameters
+func (t *ClientTransport) GetParams() (proto.Message, error) {
+	return t.Parameters, nil
 }
 
 // SetParams allows the caller to set parameters associated with the transport, returning an
@@ -56,7 +56,7 @@ func (t *ClientTransport) SetParams(p any) error {
 }
 
 // GetDstPort returns the destination port that the client should open the phantom connection to
-func (t *ClientTransport) GetDstPort(seed []byte, params any) (uint16, error) {
+func (t *ClientTransport) GetDstPort(seed []byte) (uint16, error) {
 	if t.Parameters == nil || !t.Parameters.GetRandomizeDstPort() {
 		return 443, nil
 	}

--- a/application/transports/wrapping/obfs4/obfs4.go
+++ b/application/transports/wrapping/obfs4/obfs4.go
@@ -65,6 +65,12 @@ func (Transport) ParseParams(libVersion uint, data *anypb.Any) (any, error) {
 	return m, err
 }
 
+// ParamStrings returns an array of tag string that will be added to tunStats when a proxy
+// session is closed. For now, no params of interest.
+func (t Transport) ParamStrings(p any) []string {
+	return nil
+}
+
 // WrapConnection implements the station Transport interface
 func (Transport) WrapConnection(data *bytes.Buffer, c net.Conn, phantom net.IP, regManager *cj.RegistrationManager) (*cj.DecoyRegistration, net.Conn, error) {
 	if data.Len() < ClientMinHandshakeLength {

--- a/application/transports/wrapping/obfs4/obfs4_test.go
+++ b/application/transports/wrapping/obfs4/obfs4_test.go
@@ -62,7 +62,7 @@ func TestSuccessfulWrap(t *testing.T) {
 
 	var transport Transport
 	manager := tests.SetupRegistrationManager(tests.Transport{Index: pb.TransportType_Obfs4, Transport: transport})
-	c2p, sfp, reg := tests.SetupPhantomConnections(manager, pb.TransportType_Obfs4, 0)
+	c2p, sfp, reg := tests.SetupPhantomConnections(manager, pb.TransportType_Obfs4, nil, 0)
 	defer c2p.Close()
 	defer sfp.Close()
 
@@ -138,7 +138,7 @@ func TestSuccessfulWrapMulti(t *testing.T) {
 
 	// register 5 sessions guaranteeing collisions on phantom IP addresses
 	for _, secret := range sharedSecrets {
-		c2p, sfp, reg = tests.SetupPhantomConnectionsSecret(manager, pb.TransportType_Obfs4, secret, 2, testSubnetPath)
+		c2p, sfp, reg = tests.SetupPhantomConnectionsSecret(manager, pb.TransportType_Obfs4, nil, secret, 2, testSubnetPath)
 	}
 
 	defer c2p.Close()
@@ -190,7 +190,7 @@ func TestUnsuccessfulWrap(t *testing.T) {
 	var transport Transport
 	var err error
 	manager := tests.SetupRegistrationManager(tests.Transport{Index: pb.TransportType_Obfs4, Transport: transport})
-	c2p, sfp, reg := tests.SetupPhantomConnections(manager, pb.TransportType_Obfs4, 2)
+	c2p, sfp, reg := tests.SetupPhantomConnections(manager, pb.TransportType_Obfs4, nil, 2)
 	defer c2p.Close()
 	defer sfp.Close()
 
@@ -212,7 +212,7 @@ func TestTryAgain(t *testing.T) {
 	var transport Transport
 	var err error
 	manager := tests.SetupRegistrationManager(tests.Transport{Index: pb.TransportType_Obfs4, Transport: transport})
-	c2p, sfp, reg := tests.SetupPhantomConnections(manager, pb.TransportType_Obfs4, 0)
+	c2p, sfp, reg := tests.SetupPhantomConnections(manager, pb.TransportType_Obfs4, nil, 0)
 	defer c2p.Close()
 	defer sfp.Close()
 
@@ -292,13 +292,15 @@ func TestTryParamsToDstPort(t *testing.T) {
 		ct := ClientTransport{Parameters: &pb.GenericTransportParams{RandomizeDstPort: &testCase.r}}
 		var transport Transport
 
-		rawParams, err := anypb.New(ct.GetParams())
+		params, err := ct.GetParams()
+		require.Nil(t, err)
+		rawParams, err := anypb.New(params)
 		require.Nil(t, err)
 
-		params, err := transport.ParseParams(clv, rawParams)
+		newParams, err := transport.ParseParams(clv, rawParams)
 		require.Nil(t, err)
 
-		port, err := transport.GetDstPort(clv, seed, params)
+		port, err := transport.GetDstPort(clv, seed, newParams)
 		require.Nil(t, err)
 		require.Equal(t, testCase.p, port)
 	}

--- a/application/transports/wrapping/prefix/client.go
+++ b/application/transports/wrapping/prefix/client.go
@@ -79,11 +79,13 @@ func (t *ClientTransport) GetParams() (proto.Message, error) {
 		return nil, fmt.Errorf("%w: empty or invalid Prefix provided", ErrBadParams)
 	}
 
-	id := int32(t.Prefix.ID())
-	F := false
-	t.parameters = &pb.PrefixTransportParams{
-		PrefixId:         &id,
-		RandomizeDstPort: &F,
+	if t.parameters == nil {
+		id := int32(t.Prefix.ID())
+		F := false
+		t.parameters = &pb.PrefixTransportParams{
+			PrefixId:         &id,
+			RandomizeDstPort: &F,
+		}
 	}
 
 	return t.parameters, nil

--- a/application/transports/wrapping/prefix/client.go
+++ b/application/transports/wrapping/prefix/client.go
@@ -97,6 +97,9 @@ func (t *ClientTransport) Build() ([]byte, error) {
 	// Send hmac(seed, str) bytes to indicate to station (min transport)
 	prefix := t.Prefix.Bytes
 
+	if t.TagObfuscator == nil {
+		t.TagObfuscator = transports.CTRObfuscator{}
+	}
 	obfuscatedID, err := t.TagObfuscator.Obfuscate(t.connectTag, t.stationPublicKey[:])
 	if err != nil {
 		return nil, err

--- a/application/transports/wrapping/prefix/client.go
+++ b/application/transports/wrapping/prefix/client.go
@@ -1,8 +1,10 @@
 package prefix
 
 import (
+	"crypto/rand"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 
 	"github.com/refraction-networking/conjure/application/transports"
@@ -16,7 +18,8 @@ import (
 // the station side Transport struct has one instance to be re-used for all sessions.
 type ClientTransport struct {
 	// Parameters are fields that will be shared with the station in the registration
-	Parameters *pb.PrefixTransportParams
+	Parameters *ClientParams
+	parameters *pb.PrefixTransportParams
 
 	// // state tracks fields internal to the registrar that survive for the lifetime
 	// // of the transport session without being shared - i.e. local derived keys.
@@ -29,33 +32,31 @@ type ClientTransport struct {
 	stationPublicKey [32]byte
 }
 
-// Prefix struct used selected by, or given to the client.
-type Prefix struct {
-	Bytes []byte
-	ID    PrefixID
+// ClientParams are parameters avaialble to configure the Prefix transport
+// outside of the specific Prefix
+type ClientParams struct {
+	RandomizeDstPort bool
+}
 
-	// // Function allowing encoding / transformation of obfuscated ID bytes after they have been
-	// // obfuscated. Examples - base64 encode, padding
-	// [FUTURE WORK]
-	// tagEncode() func([]byte) ([]byte, int, error)
-
-	// // Function allowing encoding / transformation of stream bytes after they have been. Examples
-	// // - base64 encode, padding
-	// [FUTURE WORK]
-	// streamEncode() func([]byte) ([]byte, int, error)
+// Prefix struct used by, selected by, or given to the client. This interface allows for non-uniform
+// behavior like a rand prefix for example.
+type Prefix interface {
+	Bytes() []byte
+	ID() PrefixID
+	DstPort([]byte) uint16
 }
 
 // DefaultPrefixes provides the prefixes supported by default for use when by the client.
-var DefaultPrefixes = []Prefix{}
+var DefaultPrefixes = map[PrefixID]Prefix{}
 
 // Name returns the human-friendly name of the transport, implementing the Transport interface.
 func (t *ClientTransport) Name() string {
-	return "prefix_" + t.Prefix.ID.Name()
+	return "prefix_" + t.Prefix.ID().Name()
 }
 
 // String returns a string identifier for the Transport for logging (including string formatters)
 func (t *ClientTransport) String() string {
-	return "prefix_" + t.Prefix.ID.Name()
+	return "prefix_" + t.Prefix.ID().Name()
 }
 
 // ID provides an identifier that will be sent to the conjure station during the registration so
@@ -66,8 +67,26 @@ func (*ClientTransport) ID() pb.TransportType {
 
 // GetParams returns a generic protobuf with any parameters from both the registration and the
 // transport.
-func (t *ClientTransport) GetParams() proto.Message {
-	return t.Parameters
+func (t *ClientTransport) GetParams() (proto.Message, error) {
+	if t == nil {
+		return nil, ErrBadParams
+	}
+
+	if t.Prefix == nil {
+		return nil, fmt.Errorf("%w: empty or invalid Prefix provided", ErrBadParams)
+	}
+
+	if t.Parameters == nil {
+		t.Parameters = &ClientParams{false}
+	}
+
+	id := int32(t.Prefix.ID())
+	t.parameters = &pb.PrefixTransportParams{
+		PrefixId:         &id,
+		RandomizeDstPort: &t.Parameters.RandomizeDstPort,
+	}
+
+	return t.parameters, nil
 }
 
 // SetParams allows the caller to set parameters associated with the transport, returning an
@@ -75,27 +94,45 @@ func (t *ClientTransport) GetParams() proto.Message {
 func (t *ClientTransport) SetParams(p any) error {
 	params, ok := p.(*pb.PrefixTransportParams)
 	if !ok {
-		return fmt.Errorf("unable to parse params")
+		return ErrBadParams
 	}
-	t.Parameters = params
+	t.parameters = params
 
 	return nil
 }
 
 // GetDstPort returns the destination port that the client should open the phantom connection to
-func (t *ClientTransport) GetDstPort(seed []byte, params any) (uint16, error) {
-	if t.Parameters == nil || !t.Parameters.GetRandomizeDstPort() {
-		return 443, nil
+func (t *ClientTransport) GetDstPort(seed []byte) (uint16, error) {
+
+	if t == nil {
+		return 0, ErrBadParams
 	}
 
-	return transports.PortSelectorRange(portRangeMin, portRangeMax, seed)
+	if t.Prefix == nil {
+		return 0, fmt.Errorf("%w: empty or invalid Prefix provided", ErrBadParams)
+	}
+
+	if t.Parameters == nil {
+		t.Parameters = &ClientParams{false}
+	}
+
+	prefixID := t.Prefix.ID()
+
+	if prefixID == Rand {
+		return 0, fmt.Errorf("%w: use FromID() if using Rand prefix", ErrUnknownPrefix)
+	}
+
+	if t.Parameters.RandomizeDstPort {
+		return transports.PortSelectorRange(portRangeMin, portRangeMax, seed)
+	}
+	return t.Prefix.DstPort(seed), nil
 }
 
 // Build is specific to the Prefix transport, providing a utility function for building the
 // prefix that the client should write to the wire before sending any client bytes.
 func (t *ClientTransport) Build() ([]byte, error) {
 	// Send hmac(seed, str) bytes to indicate to station (min transport)
-	prefix := t.Prefix.Bytes
+	prefix := t.Prefix.Bytes()
 
 	if t.TagObfuscator == nil {
 		t.TagObfuscator = transports.CTRObfuscator{}
@@ -134,4 +171,61 @@ func (t *ClientTransport) WrapConn(conn net.Conn) (net.Conn, error) {
 		return nil, err
 	}
 	return conn, nil
+}
+
+// ---
+
+type clientPrefix struct {
+	bytes []byte
+	id    PrefixID
+	port  uint16
+
+	// // Function allowing encoding / transformation of obfuscated ID bytes after they have been
+	// // obfuscated. Examples - base64 encode, padding
+	// [FUTURE WORK]
+	// tagEncode() func([]byte) ([]byte, int, error)
+
+	// // Function allowing encoding / transformation of stream bytes after they have been. Examples
+	// // - base64 encode, padding
+	// [FUTURE WORK]
+	// streamEncode() func([]byte) ([]byte, int, error)
+}
+
+func (c *clientPrefix) Bytes() []byte {
+	return c.bytes
+}
+
+func (c *clientPrefix) ID() PrefixID {
+	return c.id
+}
+
+func (c *clientPrefix) DstPort([]byte) uint16 {
+	return c.port
+}
+
+// ---
+
+// TryFromID returns a Prefix based on the Prefix ID. This is useful for non-static prefixes like the
+// random prefix
+func TryFromID(id PrefixID) (Prefix, error) {
+
+	if len(DefaultPrefixes) == 0 || id < Rand || int(id) > len(DefaultPrefixes) {
+		return nil, ErrUnknownPrefix
+	}
+
+	if id == Rand {
+		return pickRandomPrefix(rand.Reader)
+	}
+
+	return DefaultPrefixes[id], nil
+}
+
+func pickRandomPrefix(r io.Reader) (Prefix, error) {
+	var n = big.NewInt(int64(len(DefaultPrefixes)))
+	i, err := rand.Int(r, n)
+	if err != nil {
+		return nil, err
+	}
+
+	return DefaultPrefixes[PrefixID(i.Int64())], nil
 }

--- a/application/transports/wrapping/prefix/prefix.go
+++ b/application/transports/wrapping/prefix/prefix.go
@@ -58,6 +58,10 @@ type prefix struct {
 
 	// Minimum client library version that supports this prefix
 	MinVer uint
+
+	// Default DST Port for this prefix. We are not bound by client_lib_version (yet) so we can set the
+	// default destination port for each prefix individually
+	DefaultDstPort uint16
 }
 
 // PrefixID provide an integer Identifier for each individual prefixes allowing clients to indicate
@@ -65,7 +69,8 @@ type prefix struct {
 type PrefixID int
 
 const (
-	Min PrefixID = iota
+	Rand PrefixID = -1 + iota
+	Min
 	GetLong
 	PostLong
 	HTTPResp
@@ -75,12 +80,16 @@ const (
 	TLSAlertFatal
 	DNSOverTCP
 	OpenSSH2
-	// GetShort
+	// GetShortBase64
 )
 
 var (
 	// ErrUnknownPrefix indicates that the provided Prefix ID is unknown to the transport object.
 	ErrUnknownPrefix = errors.New("unknown / unsupported prefix")
+
+	// ErrBadParams indicates that the parameters provided to a call on the server side do not make
+	// sense in the context that they are provided and the registration will be ignored.
+	ErrBadParams = errors.New("bad parameters provided")
 )
 
 // Name returns the human-friendly name of the prefix.
@@ -88,7 +97,6 @@ func (id PrefixID) Name() string {
 	switch id {
 	case Min:
 		return "Min"
-
 	case GetLong:
 		return "GetLong"
 	case PostLong:
@@ -117,28 +125,28 @@ func (id PrefixID) Name() string {
 // defaultPrefixes provides the prefixes supported by default for use when
 // initializing the prefix transport.
 var defaultPrefixes = map[PrefixID]prefix{
+	//Min - Empty prefix
+	Min: {[]byte{}, 0, minTagLength, minTagLength, randomizeDstPortMinVersion, 443},
+	// HTTP GET
+	GetLong: {[]byte("GET / HTTP/1.1\r\n"), 16, 16 + minTagLength, 16 + minTagLength, randomizeDstPortMinVersion, 80},
+	// HTTP POST
+	PostLong: {[]byte("POST / HTTP/1.1\r\n"), 17, 17 + minTagLength, 17 + minTagLength, randomizeDstPortMinVersion, 80},
+	// HTTP Response
+	HTTPResp: {[]byte("HTTP/1.1 200\r\n"), 14, 14 + minTagLength, 14 + minTagLength, randomizeDstPortMinVersion, 80},
+	// TLS Client Hello
+	TLSClientHello: {[]byte("\x16\x03\x01\x40\x00\x01"), 6, 6 + minTagLength, 6 + minTagLength, randomizeDstPortMinVersion, 443},
+	// TLS Server Hello
+	TLSServerHello: {[]byte("\x16\x03\x03\x40\x00\x02\r\n"), 8, 8 + minTagLength, 8 + minTagLength, randomizeDstPortMinVersion, 443},
+	// TLS Alert Warning
+	TLSAlertWarning: {[]byte("\x15\x03\x01\x00\x02"), 5, 5 + minTagLength, 5 + minTagLength, randomizeDstPortMinVersion, 443},
+	// TLS Alert Fatal
+	TLSAlertFatal: {[]byte("\x15\x03\x02\x00\x02"), 5, 5 + minTagLength, 5 + minTagLength, randomizeDstPortMinVersion, 443},
+	// DNS over TCP
+	DNSOverTCP: {[]byte("\x05\xDC\x5F\xE0\x01\x20"), 6, 6 + minTagLength, 6 + minTagLength, randomizeDstPortMinVersion, 53},
+	// SSH-2.0-OpenSSH_8.9p1
+	OpenSSH2: {[]byte("SSH-2.0-OpenSSH_8.9p1"), 21, 21 + minTagLength, 21 + minTagLength, randomizeDstPortMinVersion, 22},
 	// // HTTP GET base64 in url min tag length 88 because 64 bytes base64 encoded should be length 88
 	// GetShort: {base64TagDecode, []byte("GET /"), 5, 5 + 88, 5 + 88, randomizeDstPortMinVersion},
-	// HTTP GET
-	GetLong: {[]byte("GET / HTTP/1.1\r\n"), 16, 16 + minTagLength, 16 + minTagLength, randomizeDstPortMinVersion},
-	// HTTP POST
-	PostLong: {[]byte("POST / HTTP/1.1\r\n"), 17, 17 + minTagLength, 17 + minTagLength, randomizeDstPortMinVersion},
-	// HTTP Response
-	HTTPResp: {[]byte("HTTP/1.1 200\r\n"), 14, 14 + minTagLength, 14 + minTagLength, randomizeDstPortMinVersion},
-	// TLS Client Hello
-	TLSClientHello: {[]byte("\x16\x03\x01\x40\x00\x01"), 6, 6 + minTagLength, 6 + minTagLength, randomizeDstPortMinVersion},
-	// TLS Server Hello
-	TLSServerHello: {[]byte("\x16\x03\x03\x40\x00\x02\r\n"), 8, 8 + minTagLength, 8 + minTagLength, randomizeDstPortMinVersion},
-	// TLS Alert Warning
-	TLSAlertWarning: {[]byte("\x15\x03\x01\x00\x02"), 5, 5 + minTagLength, 5 + minTagLength, randomizeDstPortMinVersion},
-	// TLS Alert Fatal
-	TLSAlertFatal: {[]byte("\x15\x03\x02\x00\x02"), 5, 5 + minTagLength, 5 + minTagLength, randomizeDstPortMinVersion},
-	// DNS over TCP
-	DNSOverTCP: {[]byte("\x05\xDC\x5F\xE0\x01\x20"), 6, 6 + minTagLength, 6 + minTagLength, randomizeDstPortMinVersion},
-	// SSH-2.0-OpenSSH_8.9p1
-	OpenSSH2: {[]byte("SSH-2.0-OpenSSH_8.9p1"), 21, 21 + minTagLength, 21 + minTagLength, randomizeDstPortMinVersion},
-	//Min - Empty prefix
-	Min: {[]byte{}, 0, minTagLength, minTagLength, randomizeDstPortMinVersion},
 }
 
 // Transport provides a struct implementing the Transport, WrappingTransport,
@@ -170,20 +178,16 @@ func (Transport) GetProto() pb.IPProto {
 	return pb.IPProto_Tcp
 }
 
-// ParseParams gives the specific transport an option to parse a generic object
-// into parameters provided by the client during registration.
+// ParseParams gives the specific transport an option to parse a generic object into parameters
+// provided by the client during registration. This Transport was written after RandomizeDstPort was
+// added, so it should not be usable by clients who don't support destination port randomization.
 func (t Transport) ParseParams(libVersion uint, data *anypb.Any) (any, error) {
 	if data == nil {
 		return nil, nil
 	}
 
-	// For backwards compatibility we create a generic transport params object
-	// for transports that existed before the transportParams fields existed.
 	if libVersion < randomizeDstPortMinVersion {
-		f := false
-		return &pb.PrefixTransportParams{
-			RandomizeDstPort: &f,
-		}, nil
+		return nil, fmt.Errorf("client couldn't support this transport")
 	}
 
 	var m = &pb.PrefixTransportParams{}
@@ -214,26 +218,31 @@ func (t Transport) ParamStrings(p any) []string {
 // GetDstPort Given the library version, a seed, and a generic object
 // containing parameters the transport should be able to return the
 // destination port that a clients phantom connection will attempt to reach
-func (Transport) GetDstPort(libVersion uint, seed []byte, params any) (uint16, error) {
+func (t Transport) GetDstPort(libVersion uint, seed []byte, params any) (uint16, error) {
 
 	if libVersion < randomizeDstPortMinVersion {
-		return 443, nil
+		return 0, fmt.Errorf("client couldn't support this transport")
 	}
-
-	if params == nil {
-		return 443, nil
-	}
-
 	parameters, ok := params.(*pb.PrefixTransportParams)
 	if !ok {
-		return 0, fmt.Errorf("bad parameters provided")
+		return 0, ErrBadParams
+	}
+
+	if parameters == nil {
+		return 0, ErrBadParams
+	}
+
+	prefix := parameters.GetPrefixId()
+	p, ok := t.SupportedPrefixes[PrefixID(prefix)]
+	if !ok {
+		return 0, ErrUnknownPrefix
 	}
 
 	if parameters.GetRandomizeDstPort() {
 		return transports.PortSelectorRange(portRangeMin, portRangeMax, seed)
 	}
 
-	return 443, nil
+	return p.DefaultDstPort, nil
 }
 
 // WrapConnection attempts to wrap the given connection in the transport. It
@@ -361,12 +370,16 @@ func tryParsePrefixes(filepath string) (map[PrefixID]prefix, error) {
 	return nil, nil
 }
 
-func init() {
+func applyDefaultPrefixes() {
 	// if at any point we need to do init on the prefixes (i.e compiling regular expressions) it
 	// should happen here.
 	for ID, p := range defaultPrefixes {
-		DefaultPrefixes = append(DefaultPrefixes, Prefix{p.StaticMatch, ID})
+		DefaultPrefixes[ID] = &clientPrefix{p.StaticMatch, ID, p.DefaultDstPort}
 	}
+}
+
+func init() {
+	applyDefaultPrefixes()
 }
 
 func min(a, b int) int {

--- a/application/transports/wrapping/prefix/prefix.go
+++ b/application/transports/wrapping/prefix/prefix.go
@@ -10,7 +10,6 @@ import (
 	"github.com/refraction-networking/conjure/application/transports"
 	"github.com/refraction-networking/conjure/pkg/core"
 	pb "github.com/refraction-networking/gotapdance/protobuf"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -188,7 +187,7 @@ func (t Transport) ParseParams(libVersion uint, data *anypb.Any) (any, error) {
 	}
 
 	var m = &pb.PrefixTransportParams{}
-	err := anypb.UnmarshalTo(data, m, proto.UnmarshalOptions{})
+	err := transports.UnmarshalAnypbTo(data, m)
 
 	// Check if this is a prefix that we know how to parse, if not, drop the registration because
 	// we will be unable to pick up.
@@ -197,6 +196,19 @@ func (t Transport) ParseParams(libVersion uint, data *anypb.Any) (any, error) {
 	}
 
 	return m, err
+}
+
+// ParamStrings returns an array of tag string that will be added to tunStats when a proxy session
+// is closed.
+func (t Transport) ParamStrings(p any) []string {
+	params, ok := p.(*pb.PrefixTransportParams)
+	if !ok {
+		return nil
+	}
+
+	out := []string{PrefixID(params.GetPrefixId()).Name()}
+
+	return out
 }
 
 // GetDstPort Given the library version, a seed, and a generic object


### PR DESCRIPTION
This is a follow-on to #165 that cleans up several things that were missed, like 
* stats logging w/ selective parameters
* Prefix compatibility with `transports.NewWithParams()`
* Client option to use a random prefix

client side changes
https://github.com/refraction-networking/gotapdance/pull/121
https://github.com/refraction-networking/gotapdance/pull/124