### PR TITLE
Crash Debug 

### DIFF
--- a/application/conns_test.go
+++ b/application/conns_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"io"
+	"io/ioutil"
 	golog "log"
+	"math"
 	"net"
 	"os"
 	"sync"
@@ -37,7 +40,7 @@ func (m *MockGeoIP) ASN(ip net.IP) (uint, error) {
 	// return 0, nil
 }
 
-func TestHandleNewTCPConn(t *testing.T) {
+func TestConnHandleNewTCPConn(t *testing.T) {
 	testSubnetPath := os.Getenv("GOPATH") + "/src/github.com/refraction-networking/conjure/application/lib/test/phantom_subnets.toml"
 	os.Setenv("PHANTOM_SUBNET_LOCATION", testSubnetPath)
 
@@ -49,6 +52,8 @@ func TestHandleNewTCPConn(t *testing.T) {
 	connManager := newConnManager(nil)
 	ip := net.ParseIP("8.8.8.8")
 	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
 
 	// Create a WaitGroup to synchronize the test execution
 	var wg sync.WaitGroup
@@ -56,7 +61,7 @@ func TestHandleNewTCPConn(t *testing.T) {
 
 	// Call the handleNewTCPConn function in a separate goroutine
 	go func() {
-		connManager.handleNewTCPConn(rm, clientConn, ip)
+		connManager.handleNewTCPConn(rm, serverConn, ip)
 		wg.Done()
 	}()
 
@@ -65,7 +70,7 @@ func TestHandleNewTCPConn(t *testing.T) {
 	go func() {
 		// Add a small delay before writing data to allow handleNewTCPConn to start reading
 		time.Sleep(200 * time.Millisecond)
-		_, err := serverConn.Write([]byte("Hello, server!"))
+		_, err := clientConn.Write([]byte("Hello, server!"))
 		if err != nil {
 			t.Errorf("failed to write data to server: %v", err)
 		}
@@ -73,7 +78,7 @@ func TestHandleNewTCPConn(t *testing.T) {
 
 	// Simulate receiving data from the server
 	serverData := make([]byte, len(clientData))
-	_, err := io.ReadFull(clientConn, serverData)
+	_, err := io.ReadFull(serverConn, serverData)
 	if err != nil {
 		t.Fatalf("failed to read data from server: %v", err)
 	}
@@ -83,17 +88,11 @@ func TestHandleNewTCPConn(t *testing.T) {
 		t.Errorf("unexpected data received by the server: got %q, want %q", serverData, clientData)
 	}
 
-	// Close the server connection
-	serverConn.Close()
-
 	// Wait for the handleNewTCPConn function to finish processing
 	wg.Wait()
-
-	// Close the client connection
-	clientConn.Close()
 }
 
-func TestPrintAndReset(t *testing.T) {
+func TestConnPrintAndReset(t *testing.T) {
 	logger := log.New(os.Stdout, "[TEST CONN STATS] ", golog.Ldate|golog.Lmicroseconds)
 	connManager := newConnManager(nil)
 	newGeoIPMap := make(map[uint]*asnCounts)
@@ -123,4 +122,125 @@ func TestPrintAndReset(t *testing.T) {
 	connManager.connStats.numReset = 17
 	connManager.connStats.geoIPMap = newGeoIPMap
 	connManager.connStats.PrintAndReset(logger)
+}
+
+func TestConnHandleConcurrent(t *testing.T) {
+	// We don't actually care about what gets written
+	logger := log.New(ioutil.Discard, "[TEST CONN STATS] ", golog.Ldate|golog.Lmicroseconds)
+
+	testSubnetPath := os.Getenv("GOPATH") + "/src/github.com/refraction-networking/conjure/application/lib/test/phantom_subnets.toml"
+	os.Setenv("PHANTOM_SUBNET_LOCATION", testSubnetPath)
+
+	rm := cj.NewRegistrationManager(&cj.RegConfig{})
+
+	db := &MockGeoIP{}
+	rm.GeoIP = db
+
+	connManager := newConnManager(nil)
+
+	go func() {
+		// continuously print to force race condition
+		for {
+			connManager.connStats.PrintAndReset(logger)
+		}
+	}()
+	// Create a WaitGroup to synchronize the test execution
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			ip := net.ParseIP("8.8.8.8")
+			clientConn, serverConn := net.Pipe()
+			defer clientConn.Close()
+			defer serverConn.Close()
+
+			// Call the handleNewTCPConn function in a separate goroutine
+			go func() {
+				connManager.handleNewTCPConn(rm, serverConn, ip)
+				wg.Done()
+			}()
+
+			// Simulate sending data from the client to the server
+			clientData := []byte("Hello, server!")
+			go func() {
+				// Add a small delay before writing data to allow handleNewTCPConn to start reading
+				time.Sleep(200 * time.Millisecond)
+				_, err := clientConn.Write([]byte("Hello, server!"))
+				if err != nil {
+					t.Errorf("failed to write data to server: %v", err)
+				}
+			}()
+
+			// Simulate receiving data from the server
+			serverData := make([]byte, len(clientData))
+			_, err := io.ReadFull(serverConn, serverData)
+			if err != nil {
+				t.Logf("failed to read data from server: %v", err)
+				t.Fail()
+			}
+
+			// Verify that the server received the correct data
+			if string(serverData) != string(clientData) {
+				t.Errorf("unexpected data received by the server: got %q, want %q", serverData, clientData)
+			}
+		}()
+	}
+
+	// Wait for the handleNewTCPConn function to finish processing
+	wg.Wait()
+}
+
+func TestConnForceRace(t *testing.T) {
+	// We don't actually care about what gets written
+	logger := log.New(ioutil.Discard, "[TEST CONN STATS] ", golog.Ldate|golog.Lmicroseconds)
+	cs := &connStats{geoIPMap: make(map[uint]*asnCounts)}
+	exit := make(chan struct{})
+
+	go func() {
+		// continuously print until we receive the exit signal to force race condition
+		for {
+			select {
+			case <-exit:
+				break
+			default:
+				cs.PrintAndReset(logger)
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := 1; i <= 10; i++ {
+		wg.Add(1)
+		go func(il int) {
+			for j := 0; j < 10; j++ {
+				im := int(math.Max(float64(il), 1)) // prevent div by 0
+				asn := uint(j % im)
+				cc := fmt.Sprintf("%d", uint(j/im))
+				cs.addCreated(asn, cc)
+				cs.createdToDiscard(asn, cc)
+				cs.createdToCheck(asn, cc)
+				cs.createdToReset(asn, cc)
+				cs.createdToTimeout(asn, cc)
+				cs.createdToError(asn, cc)
+				cs.readToCheck(asn, cc)
+				cs.readToTimeout(asn, cc)
+				cs.readToReset(asn, cc)
+				cs.readToError(asn, cc)
+				cs.checkToCreated(asn, cc)
+				cs.checkToRead(asn, cc)
+				cs.checkToFound(asn, cc)
+				cs.checkToError(asn, cc)
+				cs.checkToDiscard(asn, cc)
+				cs.discardToReset(asn, cc)
+				cs.discardToTimeout(asn, cc)
+				cs.discardToError(asn, cc)
+				cs.discardToClose(asn, cc)
+			}
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+	close(exit)
 }

--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -27,9 +27,6 @@ var (
 	// errConnTimeout replaces the ip.timeout error in the halfpipe to remove ips and extra bytes
 	errConnTimeout = errors.New("timeout")
 
-	// errBrokenPipe replaces the write: broken pipe error to prevent client IP logging
-	errBrokenPipe = errors.New("broken_pipe")
-
 	// replaces refused error to prevent client IP logging
 	errConnRefused = errors.New("refused")
 
@@ -95,7 +92,7 @@ func halfPipe(src net.Conn, dst net.Conn,
 		if ok {
 			e := cTCP.SetLinger(resetIfNotClosedAfter)
 			if eg := generalizeErr(e); eg != nil {
-				logger.Errorf("failed to SetLinger: %w", eg)
+				logger.Errorln("failed to SetLinger: ", eg)
 			}
 		}
 

--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -98,12 +98,10 @@ func halfPipe(src net.Conn, dst net.Conn,
 			e := cTCP.SetLinger(resetIfNotClosedAfter)
 			if eg := generalizeErr(e); eg != nil {
 				logger.Errorf("failed to SetLinger: %w", eg)
-			} else {
-				errConnClose = cTCP.Close()
 			}
-		} else {
-			errConnClose = c.Close()
 		}
+
+		errConnClose = c.Close()
 
 		if eg := generalizeErr(errConnClose); eg != nil {
 			if errors.Is(eg, errConnTimeout) {

--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -83,6 +83,27 @@ func halfPipe(src net.Conn, dst net.Conn,
 	}
 	defer cleanup()
 
+	closeConn := func(c net.Conn) {
+		// Close dst
+		errConnClose := dst.Close()
+		if e := generalizeErr(errConnClose); e != nil {
+			if errors.Is(e, errConnTimeout) {
+				stats.CovertConnErr = e.Error()
+				stats.ClientConnErr = e.Error()
+			} else if isUpload {
+				if stats.CovertConnErr == "" {
+					stats.CovertConnErr = e.Error()
+				}
+			} else {
+				if stats.ClientConnErr == "" {
+					stats.ClientConnErr = e.Error()
+				}
+			}
+		}
+	}
+	defer closeConn(src)
+	defer closeConn(dst)
+
 	// Set deadlines in case either side disappears.
 	err := src.SetDeadline(time.Now().Add(proxyStallTimeout))
 	if err != nil {
@@ -165,40 +186,6 @@ func halfPipe(src net.Conn, dst net.Conn,
 		err = dst.SetDeadline(time.Now().Add(proxyStallTimeout))
 		if err != nil {
 			logger.Errorln("error setting deadline for dst conn: ", tag)
-		}
-	}
-
-	// Close dst
-	errDst := dst.Close()
-	if err = generalizeErr(errDst); err != nil {
-		if errors.Is(err, errConnTimeout) {
-			stats.CovertConnErr = err.Error()
-			stats.ClientConnErr = err.Error()
-		} else if isUpload {
-			if stats.CovertConnErr == "" {
-				stats.CovertConnErr = err.Error()
-			}
-		} else {
-			if stats.ClientConnErr == "" {
-				stats.ClientConnErr = err.Error()
-			}
-		}
-	}
-
-	// Close src
-	errSrc := src.Close()
-	if err = generalizeErr(errSrc); err != nil {
-		if errors.Is(err, errConnTimeout) {
-			stats.CovertConnErr = err.Error()
-			stats.ClientConnErr = err.Error()
-		} else if isUpload {
-			if stats.ClientConnErr == "" {
-				stats.ClientConnErr = err.Error()
-			}
-		} else {
-			if stats.CovertConnErr == "" {
-				stats.CovertConnErr = err.Error()
-			}
 		}
 	}
 }
@@ -457,300 +444,3 @@ func getProxyStats() *ProxyStats {
 	proxyStatsOnce.Do(initProxyStats)
 	return &proxyStatsInstance
 }
-
-// // ProxyFactory returns an internal proxy
-// func ProxyFactory(reg *DecoyRegistration, proxyProtocol uint) func(*DecoyRegistration, *net.TCPConn, net.IP) {
-// 	switch proxyProtocol {
-// 	case 0:
-// 		return func(reg *DecoyRegistration, clientConn *net.TCPConn, originalDstIP net.IP) {
-// 			twoWayProxy(reg, clientConn, originalDstIP)
-// 		}
-// 	case 1:
-// 		return func(reg *DecoyRegistration, clientConn *net.TCPConn, originalDstIP net.IP) {
-// 			threeWayProxy(reg, clientConn, originalDstIP)
-// 		}
-// 	case 2:
-// 		return func(reg *DecoyRegistration, clientConn *net.TCPConn, originalDstIP net.IP) {
-// 			// Obfs4 handler
-// 		}
-// 	default:
-// 		return func(reg *DecoyRegistration, clientConn *net.TCPConn, originalDstIP net.IP) {
-// 		}
-// 	}
-// }
-
-/*
-func twoWayProxy(reg *DecoyRegistration, clientConn *net.TCPConn, originalDstIP net.IP) {
-	var err error
-	originalDst := originalDstIP.String()
-	notReallyOriginalSrc := clientConn.RemoteAddr().String()
-	flowDescription := fmt.Sprintf("[%s -> %s (covert=%s)] ",
-		notReallyOriginalSrc, originalDst, reg.Covert)
-	logger := log.New(os.Stdout, "[2WP] "+flowDescription, log.Ldate|log.Lmicroseconds)
-	logger.Debugln("new flow")
-
-	covertConn, err := net.Dial("tcp", reg.Covert)
-	if err != nil {
-		logger.Errorf("failed to dial target: %s", err)
-		return
-	}
-	defer covertConn.Close()
-
-	if reg.Flags.GetProxyHeader() {
-		err = writePROXYHeader(covertConn, clientConn.RemoteAddr().String())
-		if err != nil {
-			logger.Errorf("failed to send PROXY header to covert: %s", err)
-			return
-		}
-	}
-
-	wg := sync.WaitGroup{}
-	oncePrintErr := sync.Once{}
-	wg.Add(2)
-
-	go halfPipe(clientConn, covertConn, &wg, &oncePrintErr, logger, "Up")
-	go halfPipe(covertConn, clientConn, &wg, &oncePrintErr, logger, "Down")
-	wg.Wait()
-}
-*/
-
-/*
-
-const (
-	tlsRecordTypeChangeCipherSpec = byte(20)
-	tlsRecordTypeHandshake        = byte(22)
-	// tlsRecordTypeAlert            = byte(21)
-	// tlsRecordTypeApplicationData  = byte(23)
-	// tlsRecordTypeHearbeat         = byte(24)
-)
-
-const (
-	TlsHandshakeTypeHelloRequest       = byte(0)
-	TlsHandshakeTypeClientHello        = byte(1)
-	TlsHandshakeTypeServerHello        = byte(2)
-	TlsHandshakeTypeNewSessionTicket   = byte(4)
-	TlsHandshakeTypeCertificate        = byte(11)
-	TlsHandshakeTypeServerKeyExchange  = byte(12)
-	TlsHandshakeTypeCertificateRequest = byte(13)
-	TlsHandshakeTypeServerHelloDone    = byte(14)
-	TlsHandshakeTypeCertificateVerify  = byte(15)
-	TlsHandshakeTypeClientKeyExchange  = byte(16)
-	TlsHandshakeTypeFinished           = byte(20)
-	TlsHandshakeTypeCertificateStatus  = byte(22)
-	TlsHandshakeTypeNextProtocol       = byte(67)
-)
-
-const (
-	TdFlagUploadOnly  = uint8(1 << 7)
-	TdFlagDarkDecoy   = uint8(1 << 6)
-	TdFlagProxyHeader = uint8(1 << 1)
-	TdFlagUseTIL      = uint8(1 << 0)
-)
-
-func threeWayProxy(reg *DecoyRegistration, clientConn *net.TCPConn, originalDstIP net.IP) {
-	maskHostPort := reg.Mask
-	targetHostPort := reg.Covert
-	masterSecret := reg.Keys.MasterSecret[:]
-	originalDst := originalDstIP.String()
-	notReallyOriginalSrc := clientConn.LocalAddr().String()
-
-	flowDescription := fmt.Sprintf("[%s -> %s(%v) -> %s] ",
-		notReallyOriginalSrc, originalDst, maskHostPort, targetHostPort)
-	logger := log.New(os.Stdout, "[3WP] "+flowDescription, log.Ldate|log.Lmicroseconds)
-
-	if _, mPort, err := net.SplitHostPort(maskHostPort); err != nil {
-		maskHostPort = net.JoinHostPort(maskHostPort, "443")
-	} else {
-		if mPort != "443" {
-			logger.Errorf("port %v is not allowed in masked host", mPort)
-			return
-		}
-	}
-	logger.Debugln("new flow")
-
-	maskedConn, err := net.DialTimeout("tcp", maskHostPort, time.Second*10)
-	if err != nil {
-		logger.Errorf("failed to dial masked host: %v", err)
-		return
-	}
-	defer maskedConn.Close()
-
-	// TODO: set timeouts
-
-	var clientRandom, serverRandom [32]byte
-	var cipherSuite uint16
-
-	clientBufConn := makeBufferedReaderConn(clientConn, bufio.NewReader(clientConn))
-	serverBufConn := makeBufferedReaderConn(maskedConn, bufio.NewReader(maskedConn))
-
-	// readFromClientAndParse returns when handshake is over
-	// returned error signals if there were any errors reading/writing
-	// If readFromClientAndParse returns successfully, following variables will be set:
-	//    clientRandom: Client Random
-	//    clientBufferedRecordSize: size of TLS record(+header) that will be sitting in clientBufConn
-	clientBufferedRecordSize := 0
-	readFromClientAndParse := func() error {
-		var clientRandomParsed bool
-		for {
-			const outerRecordHeaderLen = int(5)
-			var outerTlsHeader []byte
-			outerTlsHeader, err := clientBufConn.Peek(outerRecordHeaderLen)
-			if err != nil {
-				return err
-			}
-			outerRecordType := uint8(outerTlsHeader[0])
-			// outerRecordTlsVersion := binary.BigEndian.Uint16(outerTlsHeader[1:3])
-			outerRecordLength := int(binary.BigEndian.Uint16(outerTlsHeader[3:5]))
-
-			if outerRecordType != tlsRecordTypeHandshake && outerRecordType != tlsRecordTypeChangeCipherSpec {
-				clientBufferedRecordSize = outerRecordHeaderLen + outerRecordLength
-				return nil
-			}
-
-			if outerRecordType == tlsRecordTypeHandshake && !clientRandomParsed {
-				// next 38 bytes include type(1), length(3), version(2), clientRandom(32)
-				innerTlsHeader, err := clientBufConn.Peek(outerRecordHeaderLen + 38)
-				if err != nil {
-					return err
-				}
-				// innerRecordType := uint8(innerTlsHeader[5])
-				// innerRecordTlsLength := binary.BigEndian.Uint24(innerTlsHeader[6:9])
-				// innerRecordVersion := binary.BigEndian.Uint16(innerTlsHeader[10:11])
-				copy(clientRandom[:], innerTlsHeader[11:])
-				clientRandomParsed = true
-			}
-
-			_, err = io.CopyN(serverBufConn, clientBufConn, int64(outerRecordHeaderLen+outerRecordLength))
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	// readFromServerAndParse returns when handshake is over
-	// returned error signals if there were any errors reading/writing
-	// may set serverRandom
-	readFromServerAndParse := func() error {
-		for {
-			const outerRecordHeaderLen = 5
-			tlsHeader, err := serverBufConn.Peek(outerRecordHeaderLen)
-			if err != nil {
-				return err
-			}
-			outerRecordType := uint8(tlsHeader[0])
-			// outerRecordTlsVersion := binary.BigEndian.Uint16(tlsHeader[1:3])
-			outerRecordLength := binary.BigEndian.Uint16(tlsHeader[3:5])
-
-			if outerRecordType != tlsRecordTypeHandshake && outerRecordType != tlsRecordTypeChangeCipherSpec {
-				return nil
-			}
-
-			if outerRecordLength >= 39 {
-				// next 38 bytes are type(1), length(3), version(2), then serverRandom(32)
-				tlsHeader, err = serverBufConn.Peek(outerRecordHeaderLen + 39)
-				if err != nil {
-					return err
-				}
-				innerRecordType := uint8(tlsHeader[5])
-				// innerRecordTlsLength := binary.BigEndian.Uint24(tlsHeader[6:9])
-				// innerRecordVersion := binary.BigEndian.Uint16(tlsHeader[10:11])
-
-				if innerRecordType == TlsHandshakeTypeServerHello {
-					copy(serverRandom[:], tlsHeader[11:43])
-					sessionIdLen := int(tlsHeader[43])
-					tlsHeader, err = serverBufConn.Peek(outerRecordHeaderLen + 39 + sessionIdLen + 2)
-					if err != nil {
-						return err
-					}
-					cipherSuite = binary.BigEndian.Uint16(tlsHeader[outerRecordHeaderLen+39+sessionIdLen : outerRecordHeaderLen+39+sessionIdLen+2])
-				}
-				// then goes compressionMethod(1), extensionsLen(2), extensions(extensionsLen)
-			}
-
-			_, err = io.CopyN(clientBufConn, serverBufConn, outerRecordHeaderLen+int64(outerRecordLength))
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	serverErrChan := make(chan error)
-	go func() {
-		_err := readFromServerAndParse()
-		serverErrChan <- _err
-	}()
-
-	err = readFromClientAndParse()
-	if err != nil {
-		logger.Errorf("failed to readFromClientAndParse: %v", err)
-		return
-	}
-
-	// at this point:
-	//   readFromClientAndParse exited and there's unread non-handshake data in the conn
-	//   readFromServerAndParse is still in Peek()
-	firstAppData, err := clientBufConn.Peek(clientBufferedRecordSize)
-	if err != nil {
-		logger.Errorf("failed to peek into first app data: %v", err)
-		return
-	}
-
-	p1, p2 := net.Pipe()
-
-	inMemTlsConn := tls.MakeConnWithCompleteHandshake(
-		p1, tls.VersionTLS12, // TODO: parse version!
-		cipherSuite, masterSecret, clientRandom[:], serverRandom[:], false)
-
-	go func() {
-		_, err := p2.Write(firstAppData)
-		logger.Errorf("error closing %s", err)
-
-		p2.Close()
-	}()
-
-	var finalTargetConn net.Conn // either connection to the masked site or to real requested target
-	var finalClientConn net.Conn // original conn or forgedTlsConn
-
-	finalTargetConn = serverBufConn
-	finalClientConn = clientBufConn
-
-	decryptedFirstAppData, err := io.ReadAll(inMemTlsConn)
-	if err != nil || len(decryptedFirstAppData) == 0 {
-		logger.Debugf("not tagged: %s", err)
-	} else {
-		// almost success! now need to dial targetHostPort (TODO: do it in advance!)
-		targetConn, err := net.Dial("tcp", targetHostPort)
-		if err != nil {
-			logger.Errorf("failed to dial target: %s", err)
-		} else {
-			logger.Debugf("flow is tagged")
-			defer targetConn.Close()
-			serverBufConn.Close()
-			forgedTlsConn := tls.MakeConnWithCompleteHandshake(
-				clientBufConn, tls.VersionTLS12,
-				cipherSuite, masterSecret, clientRandom[:], serverRandom[:], false)
-			finalClientConn = forgedTlsConn
-			finalTargetConn = targetConn
-		}
-	}
-
-	wg := sync.WaitGroup{}
-	oncePrintErr := sync.Once{}
-	wg.Add(2)
-
-	go halfPipe(finalClientConn, finalTargetConn, &wg, &oncePrintErr, logger, "Up")
-
-	go func() {
-		// wait for readFromServerAndParse to exit first, as it probably haven't seen appdata yet
-		select {
-		case <-serverErrChan:
-			halfPipe(finalClientConn, finalTargetConn, &wg, &oncePrintErr, logger, "Down")
-		case <-time.After(10 * time.Second):
-			finalClientConn.Close()
-			wg.Done()
-		}
-	}()
-	wg.Wait()
-	// closes for all the things are deferred
-}
-*/

--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -89,8 +89,6 @@ func halfPipe(src net.Conn, dst net.Conn,
 	defer cleanup()
 
 	closeConn := func(c net.Conn, isSrc bool) {
-		var errConnClose error
-
 		// If the conn is TCP and close would hang because we have unacknowledged data in the buffer
 		// we force the socket to close after 10 seconds. Non-TCP sockets should not have this issue
 		cTCP, ok := c.(*net.TCPConn)
@@ -101,8 +99,7 @@ func halfPipe(src net.Conn, dst net.Conn,
 			}
 		}
 
-		errConnClose = c.Close()
-
+		errConnClose := c.Close()
 		if eg := generalizeErr(errConnClose); eg != nil {
 			if errors.Is(eg, errConnTimeout) {
 				stats.CovertConnErr = eg.Error()

--- a/application/lib/proxies.go
+++ b/application/lib/proxies.go
@@ -69,7 +69,6 @@ func generalizeErr(err error) error {
 // pass around
 func halfPipe(src net.Conn, dst net.Conn,
 	wg *sync.WaitGroup,
-	oncePrintErr *sync.Once,
 	logger *log.Logger,
 	tag string, stats *tunnelStats) {
 
@@ -260,13 +259,12 @@ func Proxy(reg *DecoyRegistration, clientConn net.Conn, logger *log.Logger) {
 	}
 
 	wg := sync.WaitGroup{}
-	oncePrintErr := sync.Once{}
 	wg.Add(2)
 
 	getProxyStats().addSession()
 
-	go halfPipe(clientConn, covertConn, &wg, &oncePrintErr, logger, "Up "+reg.IDString(), tunStats)
-	go halfPipe(covertConn, clientConn, &wg, &oncePrintErr, logger, "Down "+reg.IDString(), tunStats)
+	go halfPipe(clientConn, covertConn, &wg, logger, "Up "+reg.IDString(), tunStats)
+	go halfPipe(covertConn, clientConn, &wg, logger, "Down "+reg.IDString(), tunStats)
 	wg.Wait()
 	getProxyStats().removeSession()
 

--- a/application/lib/proxies_test.go
+++ b/application/lib/proxies_test.go
@@ -29,7 +29,6 @@ var errNotExist = errors.New("not implemented")
 func TestProxyMockCovertReset(t *testing.T) {
 
 	wg := new(sync.WaitGroup)
-	oncePrintErr := new(sync.Once)
 
 	logger := log.New(os.Stdout, "", 0)
 	logger.SetLevel(log.TraceLevel)
@@ -63,8 +62,8 @@ func TestProxyMockCovertReset(t *testing.T) {
 	}
 
 	wg.Add(2)
-	go halfPipe(clientConn, covertConn, wg, oncePrintErr, logger, "Up "+"ABCDEF", &tunnelStats{proxyStats: getProxyStats()})
-	go halfPipe(covertConn, clientConn, wg, oncePrintErr, logger, "Down "+"ABCDEF", &tunnelStats{proxyStats: getProxyStats()})
+	go halfPipe(clientConn, covertConn, wg, logger, "Up "+"ABCDEF", &tunnelStats{proxyStats: getProxyStats()})
+	go halfPipe(covertConn, clientConn, wg, logger, "Down "+"ABCDEF", &tunnelStats{proxyStats: getProxyStats()})
 
 	wg.Wait()
 }
@@ -132,11 +131,10 @@ func TestHalfpipeDeadlineEcho(t *testing.T) {
 	logger := log.New(os.Stdout, "", 0)
 	logger.SetLevel(log.TraceLevel)
 	wg := sync.WaitGroup{}
-	oncePrintErr := sync.Once{}
 	wg.Add(2)
 
-	go halfPipe(clientStation, stationCovert, &wg, &oncePrintErr, logger, "Up "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
-	go halfPipe(stationCovert, clientStation, &wg, &oncePrintErr, logger, "Down "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
+	go halfPipe(clientStation, stationCovert, &wg, logger, "Up "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
+	go halfPipe(stationCovert, clientStation, &wg, logger, "Down "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
 
 	go func() {
 		defer covertCovert.Close()
@@ -181,11 +179,10 @@ func TestHalfpipeDeadlineUpload(t *testing.T) {
 	logger := log.New(os.Stdout, "", 0)
 	logger.SetLevel(log.TraceLevel)
 	wg := sync.WaitGroup{}
-	oncePrintErr := sync.Once{}
 	wg.Add(2)
 
-	go halfPipe(clientStation, stationCovert, &wg, &oncePrintErr, logger, "Up "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
-	go halfPipe(stationCovert, clientStation, &wg, &oncePrintErr, logger, "Down "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
+	go halfPipe(clientStation, stationCovert, &wg, logger, "Up "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
+	go halfPipe(stationCovert, clientStation, &wg, logger, "Down "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
 
 	go func() {
 		defer covertCovert.Close()
@@ -226,11 +223,10 @@ func TestHalfpipeDeadlineActual(t *testing.T) {
 	logger := log.New(os.Stdout, "", 0)
 	logger.SetLevel(log.TraceLevel)
 	wg := sync.WaitGroup{}
-	oncePrintErr := sync.Once{}
 	wg.Add(2)
 
-	go halfPipe(clientStation, stationCovert, &wg, &oncePrintErr, logger, "Up "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
-	go halfPipe(stationCovert, clientStation, &wg, &oncePrintErr, logger, "Down "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
+	go halfPipe(clientStation, stationCovert, &wg, logger, "Up "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
+	go halfPipe(stationCovert, clientStation, &wg, logger, "Down "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
 
 	var serverErr error
 	go func() {

--- a/application/lib/stats.go
+++ b/application/lib/stats.go
@@ -3,6 +3,7 @@ package lib
 import (
 	golog "log"
 	"os"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -147,7 +148,7 @@ func (s *Stats) PrintStats(isVerbose bool) {
 			}
 		}
 
-		s.logger.Infof("Conns: %d cur %d new %d err Regs: %d cur %d new (%d local %d API %d shared %d unknown) %d miss %d err %d dup LiveT: %d valid %d live %d cached Byte: %d up %d down",
+		s.logger.Infof("Conns: %d cur %d new %d err Regs: %d cur %d new (%d local %d API %d shared %d unknown) %d miss %d err %d dup LiveT: %d valid %d live %d cached Byte: %d up %d down gorts %d",
 			atomic.LoadInt64(&s.activeConns), atomic.LoadInt64(&s.newConns), atomic.LoadInt64(&s.newErrConns),
 			atomic.LoadInt64(&s.activeRegistrations),
 			atomic.LoadInt64(&s.newRegistrations),
@@ -155,7 +156,8 @@ func (s *Stats) PrintStats(isVerbose bool) {
 			atomic.LoadInt64(&s.newMissedRegistrations),
 			atomic.LoadInt64(&s.newErrRegistrations), atomic.LoadInt64(&s.newDupRegistrations),
 			atomic.LoadInt64(&s.newLivenessPass), atomic.LoadInt64(&s.newLivenessFail), atomic.LoadInt64(&s.newLivenessCached),
-			atomic.LoadInt64(&s.newBytesUp), atomic.LoadInt64(&s.newBytesDown))
+			atomic.LoadInt64(&s.newBytesUp), atomic.LoadInt64(&s.newBytesDown),
+			runtime.NumGoroutine())
 		s.Reset()
 	}
 }


### PR DESCRIPTION
One of the main stations crashed overnight seeminlgly due to thread starvation in the `proxy.halfPipe()` function. In the crash logs in syslog it says: `oroutine 6_933_001 [semacquire, 4 minutes]:` which makes me things that there may have been ~7 million goroutines running.

```syslog

Jun 29 00:13:14 : conjure-app.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Jun 29 00:13:13 :         /opt/conjure/application/conns.go:66 +0x2fb
Jun 29 00:13:13 : created by main.(*connManager).acceptConnections
Jun 29 00:13:13 :         /opt/conjure/application/conns.go:112 +0x2f2
Jun 29 00:13:13 : main.(*connManager).handleNewConn(0xc025e3da40?, 0x0?, 0xc024efcdd8)
Jun 29 00:13:13 :         /opt/conjure/application/conns.go:327 +0x1bb9
Jun 29 00:13:13 : main.(*connManager).handleNewTCPConn(0xc0001f65b0, 0xc0000be460, {0xa3afb8, 0xc024efcdd8}, {0xc00d49dda0, 0x10, 0x10})
Jun 29 00:13:13 :         /opt/conjure/application/lib/proxies.go:262 +0x7a5
Jun 29 00:13:13 : github.com/refraction-networking/conjure/application/lib.Proxy(0xc008ce2700, {0xa3b0c0, 0xc01f95b240}, 0xc00254fdb0)
Jun 29 00:13:13 :         /usr/local/go/src/sync/waitgroup.go:116 +0x4b
Jun 29 00:13:13 : sync.(*WaitGroup).Wait(0xc008ce2700?)
Jun 29 00:13:13 :         /usr/local/go/src/runtime/sema.go:62 +0x27
Jun 29 00:13:13 : sync.runtime_Semacquire(0xc019ab7b00?)
Jun 29 00:13:13 : goroutine 6933001 [semacquire, 4 minutes]:
Jun 29 00:13:13 :         /opt/conjure/application/conns.go:66 +0x2fb
Jun 29 00:13:13 : created by main.(*connManager).acceptConnections
Jun 29 00:13:13 :         /opt/conjure/application/conns.go:112 +0x2f2
Jun 29 00:13:13 : main.(*connManager).handleNewConn(0x80ffaa?, 0x0?, 0xc00efb2890)
Jun 29 00:13:13 :         /opt/conjure/application/conns.go:327 +0x1bb9
Jun 29 00:13:13 : main.(*connManager).handleNewTCPConn(0xc0001f65b0, 0xc0000be460, {0xa3afb8, 0xc00efb2890}, {0xc016ea42f0, 0x10, 0x10})
Jun 29 00:13:13 :         /opt/conjure/application/lib/proxies.go:262 +0x7a5
Jun 29 00:13:13 : github.com/refraction-networking/conjure/application/lib.Proxy(0xc023754fc0, {0xa3b0c0, 0xc01f1c6a20}, 0xc00a19ac30)
Jun 29 00:13:13 :         /usr/local/go/src/sync/waitgroup.go:116 +0x4b
Jun 29 00:13:13 : sync.(*WaitGroup).Wait(0xc023754fc0?)
Jun 29 00:13:13 :         /usr/local/go/src/runtime/sema.go:62 +0x27
Jun 29 00:13:13 : sync.runtime_Semacquire(0xc005d7b260?)
Jun 29 00:13:13 : goroutine 6716000 [semacquire, 13 minutes]:

```
## test solutions

- wait on proxies failing (probably due to starvation - defer cleanup earlier for `proxy.halfpipe()`
