### PR TITLE
minor ops fixes and convenience changes

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -20,6 +20,9 @@ services:
       - /var/lib/conjure:/var/lib/conjure # config
     logging:
       driver: "journald"
+      options:
+        tag: "{{.Name}}"
+    container_name: zbalance
     restart: "always"
     command: [ "/opt/conjure/scripts/start_zbalance_ipc.sh" ]
 
@@ -39,6 +42,7 @@ services:
       - /dev/net/tun:/dev/net/tun #tun driver interface
       - /dev/hugepages:/dev/hugepages # zbalance_ipc
       - /var/lib/conjure:/var/lib/conjure # config
+    container_name: conjure-det
     command:
       [
         "bash",
@@ -55,6 +59,7 @@ services:
       - /dev/hugepages:/dev/hugepages # zbalance_ipc
       - /var/lib/conjure:/var/lib/conjure # config
       - /usr/share/GeoIP:/usr/share/GeoIP # geoip database
+    container_name: conjure-app
     command:
       [
         "bash",

--- a/src/process_packet.rs
+++ b/src/process_packet.rs
@@ -300,9 +300,6 @@ impl PerCoreGlobal {
                 zmq_msg.set_decoy_address(decoy);
                 zmq_msg.set_registration_address(src);
 
-                let repr_str = hex::encode(res.0);
-                debug!("New registration {}, {}", flow, repr_str);
-
                 let zmq_payload = match zmq_msg.write_to_bytes() {
                     Ok(b) => b,
                     Err(e) => {

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -287,12 +287,6 @@ impl SessionTracker {
         // Dark Decoys Map is not sorted by timeout, so need to check all
         map.retain(|_, v| (*v > right_now));
         let num_sessions_after = map.len();
-        if num_sessions_before != num_sessions_after {
-            debug!(
-                "Dark Decoys drops: {} - > {}",
-                num_sessions_before, num_sessions_after
-            );
-        }
         num_sessions_before - num_sessions_after
     }
 

--- a/sysconfig/conjure.conf
+++ b/sysconfig/conjure.conf
@@ -117,12 +117,13 @@ get_ifc_and_driver() {
     # FIXME: Full path to these commands?
     # Use ifconfig with -a to check down interfaces too
     # for CJ_IFACE in $(ifconfig | grep ^e | awk '{print $1}'); do
-    for CJ_IFACE in $(ifconfig -a | grep ^e | awk '{print $1}'); do
+    # for CJ_IFACE in $(ifconfig -a | grep ^e | awk '{print $1}'); do
+    for CJ_IFACE in $(/bin/ls /sys/class/net); do
         # Need additional checks to find the "right" device
         # Here we require it have no ipv4 address, be Ethernet, and be "RUNNING" per ifconfig
         # As well as using one of the 2 supported drivers.
         export CJ_IFACE
-        if ! ifconfig $CJ_IFACE | grep -q "inet\s"; then
+        if ! ip addr l $CJ_IFACE | grep -q "inet\s"; then
             # Ensure Link encap:Ethernet? (has that in ifconfig)
             if ip addr l $CJ_IFACE | grep -q "link/ether"; then
                 # In general, can't do any more tests.


### PR DESCRIPTION
Quick fixes that resolve small issues

- change to `sysconfig/conjure.conf` to use `ip` instead of ifconfig, which is not guaranteed to be installed on newer ubuntu versions
- change docker-compose to name containers and use those names when logging to journald
- remove two persistent and uninformative log lines from detector logging.