### PR TITLE
IPv4 vs IPv6 State Tracking

### DIFF
--- a/cmd/application/conns.go
+++ b/cmd/application/conns.go
@@ -417,7 +417,7 @@ func (c *connStats) PrintAndReset(logger *log.Logger) {
 	for asn, counts := range c.geoIPMap {
 		var tt float64 = math.Max(1, float64(atomic.LoadInt64(&counts.totalTransitions)))
 
-		logger.Infof("conn-stats-verbose: %d %s %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %d %d",
+		logger.Infof("conn-stats-verbose: %d %s %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %d %d %d %d",
 			asn,
 			counts.cc,
 			atomic.LoadInt64(&counts.numCreatedToDiscard),
@@ -458,7 +458,9 @@ func (c *connStats) PrintAndReset(logger *log.Logger) {
 			float64(atomic.LoadInt64(&counts.numDiscardToError))/tt,
 			float64(atomic.LoadInt64(&counts.numDiscardToClose))/tt,
 			atomic.LoadInt64(&c.numNewConns),
+			atomic.LoadInt64(&counts.numNewConns),
 			atomic.LoadInt64(&c.numResolved),
+			atomic.LoadInt64(&counts.numResolved),
 		)
 	}
 
@@ -519,6 +521,7 @@ func (c *connStats) addCreated(asn uint, cc string) {
 			c.geoIPMap[asn].cc = cc
 		}
 		atomic.AddInt64(&c.geoIPMap[asn].numCreated, 1)
+		atomic.AddInt64(&c.geoIPMap[asn].numNewConns, 1)
 	}
 }
 
@@ -574,6 +577,7 @@ func (c *connStats) createdToReset(asn uint, cc string) {
 	atomic.AddInt64(&c.numReset, 1)
 	atomic.AddInt64(&c.numCreatedToReset, 1)
 	atomic.AddInt64(&c.totalTransitions, 1)
+	atomic.AddInt64(&c.numResolved, 1)
 
 	// GeoIP tracking
 	if isValidCC(cc) {
@@ -598,6 +602,7 @@ func (c *connStats) createdToTimeout(asn uint, cc string) {
 	atomic.AddInt64(&c.numTimeout, 1)
 	atomic.AddInt64(&c.numCreatedToTimeout, 1)
 	atomic.AddInt64(&c.totalTransitions, 1)
+	atomic.AddInt64(&c.numResolved, 1)
 
 	// GeoIP tracking
 	if isValidCC(cc) {
@@ -622,6 +627,7 @@ func (c *connStats) createdToError(asn uint, cc string) {
 	atomic.AddInt64(&c.numErr, 1)
 	atomic.AddInt64(&c.numCreatedToError, 1)
 	atomic.AddInt64(&c.totalTransitions, 1)
+	atomic.AddInt64(&c.numResolved, 1)
 
 	// GeoIP tracking
 	if isValidCC(cc) {
@@ -669,6 +675,7 @@ func (c *connStats) readToTimeout(asn uint, cc string) {
 	atomic.AddInt64(&c.numTimeout, 1)
 	atomic.AddInt64(&c.numReadToTimeout, 1)
 	atomic.AddInt64(&c.totalTransitions, 1)
+	atomic.AddInt64(&c.numResolved, 1)
 
 	// GeoIP tracking
 	if isValidCC(cc) {
@@ -693,6 +700,7 @@ func (c *connStats) readToReset(asn uint, cc string) {
 	atomic.AddInt64(&c.numReset, 1)
 	atomic.AddInt64(&c.numReadToReset, 1)
 	atomic.AddInt64(&c.totalTransitions, 1)
+	atomic.AddInt64(&c.numResolved, 1)
 
 	// GeoIP tracking
 	if isValidCC(cc) {
@@ -717,6 +725,7 @@ func (c *connStats) readToError(asn uint, cc string) {
 	atomic.AddInt64(&c.numErr, 1)
 	atomic.AddInt64(&c.numReadToError, 1)
 	atomic.AddInt64(&c.totalTransitions, 1)
+	atomic.AddInt64(&c.numResolved, 1)
 
 	// GeoIP tracking
 	if isValidCC(cc) {
@@ -787,6 +796,7 @@ func (c *connStats) checkToFound(asn uint, cc string) {
 	atomic.AddInt64(&c.numFound, 1)
 	atomic.AddInt64(&c.numCheckToFound, 1)
 	atomic.AddInt64(&c.totalTransitions, 1)
+	atomic.AddInt64(&c.numResolved, 1)
 
 	// GeoIP tracking
 	if isValidCC(cc) {
@@ -811,6 +821,7 @@ func (c *connStats) checkToError(asn uint, cc string) {
 	atomic.AddInt64(&c.numErr, 1)
 	atomic.AddInt64(&c.numCheckToError, 1)
 	atomic.AddInt64(&c.totalTransitions, 1)
+	atomic.AddInt64(&c.numResolved, 1)
 
 	// GeoIP tracking
 	if isValidCC(cc) {
@@ -858,6 +869,7 @@ func (c *connStats) discardToReset(asn uint, cc string) {
 	atomic.AddInt64(&c.numReset, 1)
 	atomic.AddInt64(&c.numDiscardToReset, 1)
 	atomic.AddInt64(&c.totalTransitions, 1)
+	atomic.AddInt64(&c.numResolved, 1)
 
 	// GeoIP tracking
 	if isValidCC(cc) {
@@ -882,6 +894,7 @@ func (c *connStats) discardToTimeout(asn uint, cc string) {
 	atomic.AddInt64(&c.numTimeout, 1)
 	atomic.AddInt64(&c.numDiscardToTimeout, 1)
 	atomic.AddInt64(&c.totalTransitions, 1)
+	atomic.AddInt64(&c.numResolved, 1)
 
 	// GeoIP tracking
 	if isValidCC(cc) {
@@ -906,6 +919,7 @@ func (c *connStats) discardToError(asn uint, cc string) {
 	atomic.AddInt64(&c.numErr, 1)
 	atomic.AddInt64(&c.numDiscardToError, 1)
 	atomic.AddInt64(&c.totalTransitions, 1)
+	atomic.AddInt64(&c.numResolved, 1)
 
 	// GeoIP tracking
 	if isValidCC(cc) {
@@ -930,6 +944,7 @@ func (c *connStats) discardToClose(asn uint, cc string) {
 	atomic.AddInt64(&c.numClosed, 1)
 	atomic.AddInt64(&c.numDiscardToClose, 1)
 	atomic.AddInt64(&c.totalTransitions, 1)
+	atomic.AddInt64(&c.numResolved, 1)
 
 	// GeoIP tracking
 	if isValidCC(cc) {

--- a/cmd/application/conns.go
+++ b/cmd/application/conns.go
@@ -364,6 +364,7 @@ type statCounts struct {
 	numDiscardToClose   int64 // Number of times connections have moved from Discard to Close
 
 	totalTransitions int64 // Number of all transitions tracked
+	numConns         int64 // Number of connections from this connManager
 }
 
 type asnCounts struct {
@@ -405,7 +406,7 @@ func (c *connStats) PrintAndReset(logger *log.Logger) {
 	for asn, counts := range c.geoIPMap {
 		var tt float64 = math.Max(1, float64(atomic.LoadInt64(&counts.totalTransitions)))
 
-		logger.Infof("conn-stats-verbose: %d %s %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f",
+		logger.Infof("conn-stats-verbose: %d %s %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f",
 			asn,
 			counts.cc,
 			atomic.LoadInt64(&counts.numCreatedToDiscard),
@@ -427,6 +428,7 @@ func (c *connStats) PrintAndReset(logger *log.Logger) {
 			atomic.LoadInt64(&counts.numDiscardToError),
 			atomic.LoadInt64(&counts.numDiscardToClose),
 			atomic.LoadInt64(&counts.totalTransitions),
+			atomic.LoadInt64(&c.numConns),
 			float64(atomic.LoadInt64(&counts.numCreatedToDiscard))/tt,
 			float64(atomic.LoadInt64(&counts.numCreatedToCheck))/tt,
 			float64(atomic.LoadInt64(&counts.numCreatedToReset))/tt,
@@ -482,6 +484,7 @@ func (c *connStats) reset() {
 	atomic.StoreInt64(&c.numDiscardToError, 0)
 	atomic.StoreInt64(&c.numDiscardToClose, 0)
 	atomic.StoreInt64(&c.totalTransitions, 0)
+	atomic.StoreInt64(&c.numConns, 0)
 
 	c.geoIPMap = make(map[uint]*asnCounts)
 
@@ -491,6 +494,7 @@ func (c *connStats) reset() {
 func (c *connStats) addCreated(asn uint, cc string) {
 	// Overall tracking
 	atomic.AddInt64(&c.numCreated, 1)
+	atomic.AddInt64(&c.numConns, 1)
 
 	// GeoIP tracking
 	if isValidCC(cc) {

--- a/cmd/application/conns_test.go
+++ b/cmd/application/conns_test.go
@@ -98,17 +98,24 @@ func TestConnPrintAndReset(t *testing.T) {
 	newGeoIPMap := make(map[uint]*asnCounts)
 	newGeoIPMap[0] = &asnCounts{
 		cc: "unk",
-		statCounts: statCounts{
+		ipv4: statCounts{
 			numCreatedToDiscard: 1,
 			numCreatedToCheck:   2,
 			numCreatedToReset:   3,
 			numCreatedToTimeout: 4,
 			numCreatedToError:   5,
 		},
+		ipv6: statCounts{
+			numCreatedToDiscard: 71,
+			numCreatedToCheck:   72,
+			numCreatedToReset:   73,
+			numCreatedToTimeout: 74,
+			numCreatedToError:   75,
+		},
 	}
 	newGeoIPMap[1] = &asnCounts{
 		cc: "US",
-		statCounts: statCounts{
+		ipv6: statCounts{
 			numCreatedToDiscard: 6,
 			numCreatedToCheck:   7,
 			numCreatedToReset:   8,
@@ -117,9 +124,9 @@ func TestConnPrintAndReset(t *testing.T) {
 			totalTransitions:    2,
 		},
 	}
-	connManager.connStats.numCreated = 55
-	connManager.connStats.numCheckToError = 1
-	connManager.connStats.numReset = 17
+	connManager.connStats.ipv4.numCreated = 55
+	connManager.connStats.ipv4.numCheckToError = 1
+	connManager.connStats.ipv6.numReset = 17
 	connManager.connStats.geoIPMap = newGeoIPMap
 	connManager.connStats.PrintAndReset(logger)
 }
@@ -217,25 +224,25 @@ func TestConnForceRace(t *testing.T) {
 				im := int(math.Max(float64(il), 1)) // prevent div by 0
 				asn := uint(j % im)
 				cc := fmt.Sprintf("%d", uint(j/im))
-				cs.addCreated(asn, cc)
-				cs.createdToDiscard(asn, cc)
-				cs.createdToCheck(asn, cc)
-				cs.createdToReset(asn, cc)
-				cs.createdToTimeout(asn, cc)
-				cs.createdToError(asn, cc)
-				cs.readToCheck(asn, cc)
-				cs.readToTimeout(asn, cc)
-				cs.readToReset(asn, cc)
-				cs.readToError(asn, cc)
-				cs.checkToCreated(asn, cc)
-				cs.checkToRead(asn, cc)
-				cs.checkToFound(asn, cc)
-				cs.checkToError(asn, cc)
-				cs.checkToDiscard(asn, cc)
-				cs.discardToReset(asn, cc)
-				cs.discardToTimeout(asn, cc)
-				cs.discardToError(asn, cc)
-				cs.discardToClose(asn, cc)
+				cs.addCreated(asn, cc, true)
+				cs.createdToDiscard(asn, cc, true)
+				cs.createdToCheck(asn, cc, true)
+				cs.createdToReset(asn, cc, true)
+				cs.createdToTimeout(asn, cc, true)
+				cs.createdToError(asn, cc, true)
+				cs.readToCheck(asn, cc, true)
+				cs.readToTimeout(asn, cc, true)
+				cs.readToReset(asn, cc, true)
+				cs.readToError(asn, cc, true)
+				cs.checkToCreated(asn, cc, true)
+				cs.checkToRead(asn, cc, true)
+				cs.checkToFound(asn, cc, true)
+				cs.checkToError(asn, cc, true)
+				cs.checkToDiscard(asn, cc, true)
+				cs.discardToReset(asn, cc, true)
+				cs.discardToTimeout(asn, cc, true)
+				cs.discardToError(asn, cc, true)
+				cs.discardToClose(asn, cc, true)
 			}
 			wg.Done()
 		}(i)

--- a/cmd/application/conns_test.go
+++ b/cmd/application/conns_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	golog "log"
 	"math"
 	"net"
@@ -127,7 +126,7 @@ func TestConnPrintAndReset(t *testing.T) {
 
 func TestConnHandleConcurrent(t *testing.T) {
 	// We don't actually care about what gets written
-	logger := log.New(ioutil.Discard, "[TEST CONN STATS] ", golog.Ldate|golog.Lmicroseconds)
+	logger := log.New(io.Discard, "[TEST CONN STATS] ", golog.Ldate|golog.Lmicroseconds)
 
 	testSubnetPath := conjurepath.Root + "/pkg/station/lib/test/phantom_subnets.toml"
 	os.Setenv("PHANTOM_SUBNET_LOCATION", testSubnetPath)
@@ -194,7 +193,7 @@ func TestConnHandleConcurrent(t *testing.T) {
 
 func TestConnForceRace(t *testing.T) {
 	// We don't actually care about what gets written
-	logger := log.New(ioutil.Discard, "[TEST CONN STATS] ", golog.Ldate|golog.Lmicroseconds)
+	logger := log.New(io.Discard, "[TEST CONN STATS] ", golog.Ldate|golog.Lmicroseconds)
 	cs := &connStats{geoIPMap: make(map[uint]*asnCounts)}
 	exit := make(chan struct{})
 

--- a/cmd/application/conns_test.go
+++ b/cmd/application/conns_test.go
@@ -95,27 +95,20 @@ func TestConnHandleNewTCPConn(t *testing.T) {
 func TestConnPrintAndReset(t *testing.T) {
 	logger := log.New(os.Stdout, "[TEST CONN STATS] ", golog.Ldate|golog.Lmicroseconds)
 	connManager := newConnManager(nil)
-	newGeoIPMap := make(map[uint]*asnCounts)
-	newGeoIPMap[0] = &asnCounts{
+	v4GeoIPMap := make(map[uint]*asnCounts)
+	v4GeoIPMap[0] = &asnCounts{
 		cc: "unk",
-		ipv4: statCounts{
+		statCounts: statCounts{
 			numCreatedToDiscard: 1,
 			numCreatedToCheck:   2,
 			numCreatedToReset:   3,
 			numCreatedToTimeout: 4,
 			numCreatedToError:   5,
 		},
-		ipv6: statCounts{
-			numCreatedToDiscard: 71,
-			numCreatedToCheck:   72,
-			numCreatedToReset:   73,
-			numCreatedToTimeout: 74,
-			numCreatedToError:   75,
-		},
 	}
-	newGeoIPMap[1] = &asnCounts{
+	v4GeoIPMap[1] = &asnCounts{
 		cc: "US",
-		ipv6: statCounts{
+		statCounts: statCounts{
 			numCreatedToDiscard: 6,
 			numCreatedToCheck:   7,
 			numCreatedToReset:   8,
@@ -124,10 +117,25 @@ func TestConnPrintAndReset(t *testing.T) {
 			totalTransitions:    2,
 		},
 	}
+
+	v6GeoIPMap := make(map[uint]*asnCounts)
+	v6GeoIPMap[3] = &asnCounts{
+		cc: "IN",
+		statCounts: statCounts{
+			numCreatedToDiscard: 71,
+			numCreatedToCheck:   72,
+			numCreatedToReset:   73,
+			numCreatedToTimeout: 74,
+			numCreatedToError:   75,
+		},
+	}
+
 	connManager.connStats.ipv4.numCreated = 55
 	connManager.connStats.ipv4.numCheckToError = 1
 	connManager.connStats.ipv6.numReset = 17
-	connManager.connStats.geoIPMap = newGeoIPMap
+	connManager.connStats.v4geoIPMap = v4GeoIPMap
+	connManager.connStats.v6geoIPMap = v6GeoIPMap
+	// connManager.connStats.v6geoIPMap = make(map[uint]*asnCounts)
 	connManager.connStats.PrintAndReset(logger)
 }
 
@@ -201,7 +209,7 @@ func TestConnHandleConcurrent(t *testing.T) {
 func TestConnForceRace(t *testing.T) {
 	// We don't actually care about what gets written
 	logger := log.New(io.Discard, "[TEST CONN STATS] ", golog.Ldate|golog.Lmicroseconds)
-	cs := &connStats{geoIPMap: make(map[uint]*asnCounts)}
+	cs := &connStats{v4geoIPMap: make(map[uint]*asnCounts), v6geoIPMap: make(map[uint]*asnCounts)}
 	exit := make(chan struct{})
 
 	go func() {


### PR DESCRIPTION
All transition functions have been adjsuted to check if the connection is IPv4 or IPv6 and update the corresponding statsCount object. Printing has been updated to print 2 lines (IPv4 and IPv6) for each conn-stats and conn-stats-verbose. Tests have been updated to work with changes.