### PR TITLE
Update clean target for Makefile and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 
 backup/
-conjure
 cmd/application/application
 libtapdance/genkey
+libtapdance/*.o
+libtapdance/*.a
 cmd/registration-server/registration-server
 cmd/registration-server/regserver
 target

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ endif
 
 clean:
 	cargo clean
-	rm -rf *.o *~ ${EXE_DIR}
+	$(RM) -rf *.o *~ ${EXE_DIR}
 	cd ./libtapdance/ && make clean
 
 ${PROTO_RS_PATH}:

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,8 @@ endif
 
 clean:
 	cargo clean
-	rm -f ${TARGETS} *.o *~ ${EXE_DIR}
+	rm -rf *.o *~ ${EXE_DIR}
+	cd ./libtapdance/ && make clean
 
 ${PROTO_RS_PATH}:
 	cd ./proto/ && make


### PR DESCRIPTION
Recursively call make clean on libtapdance directory and make sure to use -r with rm to properly remove $EXE_DIR

Update .gitignore for new executable paths