### PR TITLE
Avoid nil pointer deref

### DIFF
--- a/pkg/transports/anypb_nourl.go
+++ b/pkg/transports/anypb_nourl.go
@@ -13,6 +13,12 @@ import (
 // Used to unmarshal TransportParams in the registration message for saving space from
 // the type url so that the registration payload is small enough for the DNS registrar.
 func UnmarshalAnypbTo(src *anypb.Any, dst protoreflect.ProtoMessage) error {
+	if src == nil {
+		// if a nil parameters source object is passed to us the result will also be nil and no
+		// error will be returned.
+		return nil
+	}
+
 	expected, err := anypb.New(dst)
 	if err != nil {
 		return fmt.Errorf("error reading src type: %v", err)

--- a/pkg/transports/anypb_nourl_test.go
+++ b/pkg/transports/anypb_nourl_test.go
@@ -57,6 +57,13 @@ func TestGarbage(t *testing.T) {
 	require.NotNil(t, err)
 }
 
+func TestEmpty(t *testing.T) {
+	dstAnypb := &anypb.Any{}
+
+	err := transports.UnmarshalAnypbTo(nil, dstAnypb)
+	require.Nil(t, err)
+}
+
 func TestOldProto(t *testing.T) {
 	src, err := anypb.New(&pb.GenericTransportParams{RandomizeDstPort: proto.Bool(true)})
 	require.Nil(t, err)


### PR DESCRIPTION
Fix a potential nil dereference in parameter parsing with test

```

--- FAIL: TestEmpty (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x912ecc]

goroutine 19 [running]:
testing.tRunner.func1.2({0x95a760, 0xd06e10})
        /usr/local/go/src/testing/testing.go:1545 +0x366
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1548 +0x630
panic({0x95a760?, 0xd06e10?})
        /usr/local/go/src/runtime/panic.go:920 +0x270
github.com/refraction-networking/conjure/pkg/transports.UnmarshalAnypbTo(0x0, {0xa63120, 0xc00015a370})
        /conjure/pkg/transports/anypb_nourl.go:21 +0x10c
github.com/refraction-networking/conjure/pkg/transports_test.TestEmpty(0x0?)
        /conjure/pkg/transports/anypb_nourl_test.go:63 +0x8e
testing.tRunner(0xc000103040, 0x9ebd40)
        /usr/local/go/src/testing/testing.go:1595 +0x239
created by testing.(*T).Run in goroutine 1
        /usr/local/go/src/testing/testing.go:1648 +0x82b
exit status 2
FAIL    github.com/refraction-networking/conjure/pkg/transports 0.010s
```