### PR TITLE
Unhandled Panic from `time::OffsetDateTime::now_local()`

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -26,7 +26,7 @@ impl log::Log for SimpleLogger {
             {
                 // let t = Local::now();
                 // let t_s = t.format("%Y-%m-%d %H:%M:%S.%f %z").to_string();
-                let t = OffsetDateTime::now_local().unwrap();
+                let t = OffsetDateTime::now_local().unwrap_or(OffsetDateTime::now_utc());
                 let t_s = t.format(&FORMATTER).unwrap();
                 println!("{} (Core {}) {}: {}", t_s, self.lcore_id, record.level(), s);
             }


### PR DESCRIPTION
PR #220  added an unhandled unwrap for the function call `time::OffsetDateTime::now_local()`

Turns out this can panic unexpectedly. This adds a more reliable utc fallback.