### PR TITLE
Detector log timestamp format fix

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -8,7 +8,7 @@ pub struct SimpleLogger {
     lcore_id: i32,
 }
 
-const FORMATTER: &[FormatItem<'_>]  = format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:9] [offset_hour][offset_minute]");
+const FORMATTER: &[FormatItem<'_>]  = format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:9] [offset_hour sign:mandatory][offset_minute]");
 
 impl log::Log for SimpleLogger {
     fn enabled(&self, metadata: &Metadata) -> bool {


### PR DESCRIPTION
The changes to the DateTime library used by the detector made in #221 and #220 resulted in a minor change to the actual value that gets logged (missing sign on offset hour value). This PR fixes this making our log timestamps using the `time` crate are now parse-able by the logstash grok pattern that we used for the timestamp of `chrono`.

P.S. Timestamps and time libraries are a huge hassle