### PR TITLE
phantom Select w/ random port indicated

### DIFF
--- a/pkg/regserver/regprocessor/regprocessor.go
+++ b/pkg/regserver/regprocessor/regprocessor.go
@@ -11,7 +11,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"net"
 	"sync"
 
 	zmq "github.com/pebbe/zmq4"
@@ -57,7 +56,7 @@ type zmqSender interface {
 }
 
 type ipSelector interface {
-	Select([]byte, uint, uint, bool) (net.IP, error)
+	Select([]byte, uint, uint, bool) (*lib.PhantomIP, error)
 }
 
 // RegProcessor provides an interface to publish registrations and helper functions to process registration requests
@@ -276,6 +275,7 @@ func (p *RegProcessor) processBdReq(c2sPayload *pb.C2SWrapper) (*pb.Registration
 		return nil, ErrRegProcessFailed
 	}
 
+	phantomSubnetSupportsRandPort := false
 	if c2s.GetV4Support() {
 		p.selectorMutex.RLock()
 		defer p.selectorMutex.RUnlock()
@@ -292,6 +292,7 @@ func (p *RegProcessor) processBdReq(c2sPayload *pb.C2SWrapper) (*pb.Registration
 
 		addr4 := binary.BigEndian.Uint32(phantom4.To4())
 		regResp.Ipv4Addr = &addr4
+		phantomSubnetSupportsRandPort = phantom4.SupportsPortRand
 	}
 
 	if c2s.GetV6Support() {
@@ -307,7 +308,8 @@ func (p *RegProcessor) processBdReq(c2sPayload *pb.C2SWrapper) (*pb.Registration
 			return nil, err
 		}
 
-		regResp.Ipv6Addr = phantom6
+		regResp.Ipv6Addr = *phantom6.IP
+		phantomSubnetSupportsRandPort = phantom6.SupportsPortRand
 	}
 
 	transportType := c2s.GetTransport()
@@ -322,15 +324,22 @@ func (p *RegProcessor) processBdReq(c2sPayload *pb.C2SWrapper) (*pb.Registration
 		return nil, fmt.Errorf("failed to parse transport parameters: %w", err)
 	}
 
-	dstPort, err := t.GetDstPort(uint(c2s.GetClientLibVersion()), cjkeys.ConjureSeed, params)
-	if err != nil {
-		return nil, fmt.Errorf("error determining destination port: %w", err)
-	}
+	if phantomSubnetSupportsRandPort {
+		dstPort, err := t.GetDstPort(uint(c2s.GetClientLibVersion()), cjkeys.ConjureSeed, params)
+		if err != nil {
+			return nil, fmt.Errorf("error determining destination port: %w", err)
+		}
 
-	// we have to cast to uint32 because protobuf using varint for all int / uint types and doesn't
-	// have an outward facing uint16 type.
-	port := uint32(dstPort)
-	regResp.DstPort = &port
+		// we have to cast to uint32 because protobuf using varint for all int / uint types and doesn't
+		// have an outward facing uint16 type.
+
+		port := uint32(dstPort)
+		regResp.DstPort = &port
+	} else {
+		port := uint32(443)
+		regResp.DstPort = &port
+
+	}
 
 	// Overrides will modify the C2SWrapper and put the updated registrationResponse inside to be
 	// forwarded to the station.

--- a/pkg/regserver/regprocessor/regprocessor_test.go
+++ b/pkg/regserver/regprocessor/regprocessor_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/refraction-networking/conjure/pkg/core/interfaces"
 	"github.com/refraction-networking/conjure/pkg/metrics"
 	"github.com/refraction-networking/conjure/pkg/regserver/overrides"
+	"github.com/refraction-networking/conjure/pkg/station/lib"
 	"github.com/refraction-networking/conjure/pkg/transports"
 	"github.com/refraction-networking/conjure/pkg/transports/wrapping/min"
 	"github.com/refraction-networking/conjure/pkg/transports/wrapping/prefix"
@@ -304,11 +305,11 @@ type fakeIPSelector struct {
 	v6Addr net.IP
 }
 
-func (f fakeIPSelector) Select(seed []byte, generation uint, clientLibVer uint, v6Support bool) (net.IP, error) {
+func (f fakeIPSelector) Select(seed []byte, generation uint, clientLibVer uint, v6Support bool) (*lib.PhantomIP, error) {
 	if v6Support {
-		return f.v6Addr, nil
+		return &lib.PhantomIP{IP: &f.v6Addr, SupportsPortRand: true}, nil
 	}
-	return f.v4Addr, nil
+	return &lib.PhantomIP{IP: &f.v4Addr, SupportsPortRand: true}, nil
 }
 
 func TestRegisterBidirectional(t *testing.T) {
@@ -422,8 +423,9 @@ func TestRegProcessBdReq(t *testing.T) {
 
 type mockIPSelector struct{}
 
-func (*mockIPSelector) Select([]byte, uint, uint, bool) (net.IP, error) {
-	return net.ParseIP("8.8.8.8"), nil
+func (*mockIPSelector) Select([]byte, uint, uint, bool) (*lib.PhantomIP, error) {
+	ip := net.ParseIP("8.8.8.8")
+	return &lib.PhantomIP{IP: &ip, SupportsPortRand: true}, nil
 }
 
 func TestRegProcessBdReqOverride(t *testing.T) {

--- a/pkg/station/lib/phantom_selector.go
+++ b/pkg/station/lib/phantom_selector.go
@@ -49,6 +49,7 @@ func (sc *SubnetConfig) getSubnetsVarint(seed []byte, weighted bool) ([]*phantom
 
 		choices := make([]wr.Choice, 0, len(sc.WeightedSubnets))
 		for _, cjSubnet := range sc.WeightedSubnets {
+			cjSubnet := cjSubnet // copy loop ptr
 			choices = append(choices, wr.Choice{Item: &cjSubnet, Weight: uint(cjSubnet.Weight)})
 		}
 		c, err := wr.NewChooser(choices...)

--- a/pkg/station/lib/phantom_selector.go
+++ b/pkg/station/lib/phantom_selector.go
@@ -93,6 +93,7 @@ func (sc *SubnetConfig) getSubnetsHkdf(seed []byte, weighted bool) ([]*phantomNe
 
 		totWeight := int64(0)
 		for _, cjSubnet := range weightedSubnets {
+			cjSubnet := cjSubnet // copy loop ptr
 			weight := cjSubnet.Weight
 			subnets := cjSubnet.Subnets
 			if subnets == nil {

--- a/pkg/station/lib/registration_ingest_test.go
+++ b/pkg/station/lib/registration_ingest_test.go
@@ -79,7 +79,7 @@ func TestIngestPortHandlingFunctionality(t *testing.T) {
 	seed, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
 
 	for _, testCase := range goodCases {
-		port, err := rm.getPhantomDstPort(testCase.t, testCase.p, seed, testCase.v)
+		port, err := rm.getPhantomDstPort(testCase.t, testCase.p, seed, testCase.v, true)
 		require.Nil(t, err)
 		require.Equal(t, testCase.expected, port, "case: %v", testCase)
 	}
@@ -115,7 +115,7 @@ func TestIngestPortHandlingCorners(t *testing.T) {
 	seed, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
 
 	for _, testCase := range cases {
-		_, err := rm.getPhantomDstPort(testCase.t, testCase.p, seed, testCase.v)
+		_, err := rm.getPhantomDstPort(testCase.t, testCase.p, seed, testCase.v, true)
 		require.NotNil(t, err, "case: %v", testCase)
 		require.Equal(t, testCase.err, err.Error(), "case: %v", testCase)
 	}


### PR DESCRIPTION
Make types usable outside of the package where `Select()` is used. 

Note: Some of the `TestPhantoms...` test functions are not passing seemingly because of the changes to the phantom selection. We need to make sure this is going to be backwards compatible so that the phantoms that older clients using unidirectional registrars select still match the ones we select for them.