### PR TITLE
Check subnet port randomization support on station side

### DIFF
--- a/pkg/regserver/regprocessor/regprocessor.go
+++ b/pkg/regserver/regprocessor/regprocessor.go
@@ -11,7 +11,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"net"
 	"sync"
 
 	zmq "github.com/pebbe/zmq4"
@@ -57,7 +56,7 @@ type zmqSender interface {
 }
 
 type ipSelector interface {
-	Select([]byte, uint, uint, bool) (net.IP, error)
+	Select([]byte, uint, uint, bool) (*lib.PhantomIP, error)
 }
 
 // RegProcessor provides an interface to publish registrations and helper functions to process registration requests
@@ -276,6 +275,7 @@ func (p *RegProcessor) processBdReq(c2sPayload *pb.C2SWrapper) (*pb.Registration
 		return nil, ErrRegProcessFailed
 	}
 
+	phantomSubnetSupportsRandPort := false
 	if c2s.GetV4Support() {
 		p.selectorMutex.RLock()
 		defer p.selectorMutex.RUnlock()
@@ -292,6 +292,7 @@ func (p *RegProcessor) processBdReq(c2sPayload *pb.C2SWrapper) (*pb.Registration
 
 		addr4 := binary.BigEndian.Uint32(phantom4.To4())
 		regResp.Ipv4Addr = &addr4
+		phantomSubnetSupportsRandPort = phantom4.SupportsPortRand
 	}
 
 	if c2s.GetV6Support() {
@@ -307,7 +308,8 @@ func (p *RegProcessor) processBdReq(c2sPayload *pb.C2SWrapper) (*pb.Registration
 			return nil, err
 		}
 
-		regResp.Ipv6Addr = phantom6
+		regResp.Ipv6Addr = *phantom6.IP
+		phantomSubnetSupportsRandPort = phantom6.SupportsPortRand
 	}
 
 	transportType := c2s.GetTransport()
@@ -322,15 +324,22 @@ func (p *RegProcessor) processBdReq(c2sPayload *pb.C2SWrapper) (*pb.Registration
 		return nil, fmt.Errorf("failed to parse transport parameters: %w", err)
 	}
 
-	dstPort, err := t.GetDstPort(uint(c2s.GetClientLibVersion()), cjkeys.ConjureSeed, params)
-	if err != nil {
-		return nil, fmt.Errorf("error determining destination port: %w", err)
-	}
+	if phantomSubnetSupportsRandPort {
+		dstPort, err := t.GetDstPort(uint(c2s.GetClientLibVersion()), cjkeys.ConjureSeed, params)
+		if err != nil {
+			return nil, fmt.Errorf("error determining destination port: %w", err)
+		}
 
-	// we have to cast to uint32 because protobuf using varint for all int / uint types and doesn't
-	// have an outward facing uint16 type.
-	port := uint32(dstPort)
-	regResp.DstPort = &port
+		// we have to cast to uint32 because protobuf using varint for all int / uint types and doesn't
+		// have an outward facing uint16 type.
+
+		port := uint32(dstPort)
+		regResp.DstPort = &port
+	} else {
+		port := uint32(443)
+		regResp.DstPort = &port
+
+	}
 
 	// Overrides will modify the C2SWrapper and put the updated registrationResponse inside to be
 	// forwarded to the station.

--- a/pkg/regserver/regprocessor/regprocessor_test.go
+++ b/pkg/regserver/regprocessor/regprocessor_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/refraction-networking/conjure/pkg/core/interfaces"
 	"github.com/refraction-networking/conjure/pkg/metrics"
 	"github.com/refraction-networking/conjure/pkg/regserver/overrides"
+	"github.com/refraction-networking/conjure/pkg/station/lib"
 	"github.com/refraction-networking/conjure/pkg/transports"
 	"github.com/refraction-networking/conjure/pkg/transports/wrapping/min"
 	"github.com/refraction-networking/conjure/pkg/transports/wrapping/prefix"
@@ -304,11 +305,11 @@ type fakeIPSelector struct {
 	v6Addr net.IP
 }
 
-func (f fakeIPSelector) Select(seed []byte, generation uint, clientLibVer uint, v6Support bool) (net.IP, error) {
+func (f fakeIPSelector) Select(seed []byte, generation uint, clientLibVer uint, v6Support bool) (*lib.PhantomIP, error) {
 	if v6Support {
-		return f.v6Addr, nil
+		return &lib.PhantomIP{IP: &f.v6Addr, SupportsPortRand: true}, nil
 	}
-	return f.v4Addr, nil
+	return &lib.PhantomIP{IP: &f.v4Addr, SupportsPortRand: true}, nil
 }
 
 func TestRegisterBidirectional(t *testing.T) {
@@ -422,8 +423,9 @@ func TestRegProcessBdReq(t *testing.T) {
 
 type mockIPSelector struct{}
 
-func (*mockIPSelector) Select([]byte, uint, uint, bool) (net.IP, error) {
-	return net.ParseIP("8.8.8.8"), nil
+func (*mockIPSelector) Select([]byte, uint, uint, bool) (*lib.PhantomIP, error) {
+	ip := net.ParseIP("8.8.8.8")
+	return &lib.PhantomIP{IP: &ip, SupportsPortRand: true}, nil
 }
 
 func TestRegProcessBdReqOverride(t *testing.T) {

--- a/pkg/station/lib/phantom_selector.go
+++ b/pkg/station/lib/phantom_selector.go
@@ -49,6 +49,7 @@ func (sc *SubnetConfig) getSubnetsVarint(seed []byte, weighted bool) ([]*phantom
 
 		choices := make([]wr.Choice, 0, len(sc.WeightedSubnets))
 		for _, cjSubnet := range sc.WeightedSubnets {
+			cjSubnet := cjSubnet // copy loop ptr
 			choices = append(choices, wr.Choice{Item: &cjSubnet, Weight: uint(cjSubnet.Weight)})
 		}
 		c, err := wr.NewChooser(choices...)
@@ -92,6 +93,7 @@ func (sc *SubnetConfig) getSubnetsHkdf(seed []byte, weighted bool) ([]*phantomNe
 
 		totWeight := int64(0)
 		for _, cjSubnet := range weightedSubnets {
+			cjSubnet := cjSubnet // copy loop ptr
 			weight := cjSubnet.Weight
 			subnets := cjSubnet.Subnets
 			if subnets == nil {
@@ -156,8 +158,8 @@ func V4Only(obj []*phantomNet) ([]*phantomNet, error) {
 }
 
 // V6Only - a functor for transforming the subnet list to only include IPv6 subnets
-func V6Only(obj []*net.IPNet) ([]*net.IPNet, error) {
-	var out []*net.IPNet = []*net.IPNet{}
+func V6Only(obj []*phantomNet) ([]*phantomNet, error) {
+	out := []*phantomNet{}
 
 	for _, _net := range obj {
 		if _net.IP == nil {
@@ -200,9 +202,11 @@ func NewPhantomIPSelector() (*PhantomIPSelector, error) {
 	return GetPhantomSubnetSelector()
 }
 
-type phantomIP struct {
+// PhantomIP provides a wrapper around net.IP that can be used as a net.IP, while also indicating
+// whether or not the subnet from which the address was selected supports port randomization.
+type PhantomIP struct {
 	*net.IP
-	supportRandomPort bool
+	SupportsPortRand bool
 }
 
 type phantomNet struct {
@@ -223,8 +227,7 @@ func subnetsByVersion(seed []byte, clientLibVer uint, genConfig *SubnetConfig) (
 }
 
 // Select - select an ip address from the list of subnets associated with the specified generation
-func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer uint, v6Support bool) (*phantomIP, error) {
-
+func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer uint, v6Support bool) (*PhantomIP, error) {
 	genConfig := p.GetSubnetsByGeneration(generation)
 	if genConfig == nil {
 		return nil, fmt.Errorf("generation number not recognized")
@@ -249,15 +252,22 @@ func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer ui
 		if err != nil {
 			return nil, err
 		}
-
 		return ip, nil
 	} else if clientLibVer < phantomHkdfMinVersion {
 		// Version 1
-		return selectPhantomImplVarint(seed, genSubnets)
+		ip, err := selectPhantomImplVarint(seed, genSubnets)
+		if err != nil {
+			return nil, err
+		}
+		return ip, nil
 	}
 
 	// Version 2+
-	return selectPhantomImplHkdf(seed, genSubnets)
+	ip, err := selectPhantomImplHkdf(seed, genSubnets)
+	if err != nil {
+		return nil, err
+	}
+	return ip, nil
 }
 
 // selectPhantomImplVarint - select an ip address from the list of subnets
@@ -265,7 +275,7 @@ func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer ui
 // end values for the high and low values in each allocation. The random number
 // is then bound between the global min and max of that set. This ensures that
 // addresses are chosen based on the number of addresses in the subnet.
-func selectPhantomImplVarint(seed []byte, subnets []*phantomNet) (*phantomIP, error) {
+func selectPhantomImplVarint(seed []byte, subnets []*phantomNet) (*PhantomIP, error) {
 	type idNet struct {
 		min, max big.Int
 		net      *phantomNet
@@ -312,7 +322,7 @@ func selectPhantomImplVarint(seed []byte, subnets []*phantomNet) (*phantomIP, er
 	// Find the network (ID net) that contains our random value and select a
 	// random address from that subnet.
 	// min >= id%total >= max
-	var result *phantomIP
+	var result *PhantomIP
 	for _, _idNet := range idNets {
 		// fmt.Printf("tot:%s, seed%%tot:%s     id cmp max: %d,  id cmp min: %d %s\n", addressTotal.String(), id, _idNet.max.Cmp(id), _idNet.min.Cmp(id), _idNet.net.String())
 		if _idNet.max.Cmp(id) >= 0 && _idNet.min.Cmp(id) <= 0 {
@@ -321,7 +331,7 @@ func selectPhantomImplVarint(seed []byte, subnets []*phantomNet) (*phantomIP, er
 				return nil, fmt.Errorf("failed to chose IP address: %v", err)
 			}
 
-			result = &phantomIP{IP: &res, supportRandomPort: _idNet.net.supportRandomPort}
+			result = &PhantomIP{IP: &res, SupportsPortRand: _idNet.net.supportRandomPort}
 		}
 	}
 
@@ -334,7 +344,7 @@ func selectPhantomImplVarint(seed []byte, subnets []*phantomNet) (*phantomIP, er
 
 // selectPhantomImplV0 implements support for the legacy (buggy) client phantom
 // address selection algorithm.
-func selectPhantomImplV0(seed []byte, subnets []*phantomNet) (*phantomIP, error) {
+func selectPhantomImplV0(seed []byte, subnets []*phantomNet) (*PhantomIP, error) {
 
 	addressTotal := big.NewInt(0)
 
@@ -377,14 +387,14 @@ func selectPhantomImplV0(seed []byte, subnets []*phantomNet) (*phantomIP, error)
 		id.Mod(id, addressTotal)
 	}
 
-	var result *phantomIP
+	var result *PhantomIP
 	for _, _idNet := range idNets {
 		if _idNet.max.Cmp(id) >= 0 && _idNet.min.Cmp(id) == -1 {
 			res, err := SelectAddrFromSubnet(seed, _idNet.net.IPNet)
 			if err != nil {
 				return nil, fmt.Errorf("failed to chose IP address: %v", err)
 			}
-			result = &phantomIP{IP: &res, supportRandomPort: _idNet.net.supportRandomPort}
+			result = &PhantomIP{IP: &res, SupportsPortRand: _idNet.net.supportRandomPort}
 		}
 	}
 	if result == nil {
@@ -472,7 +482,7 @@ func SelectAddrFromSubnetOffset(net1 *net.IPNet, offset *big.Int) (net.IP, error
 // end values for the high and low values in each allocation. The random number
 // is then bound between the global min and max of that set. This ensures that
 // addresses are chosen based on the number of addresses in the subnet.
-func selectPhantomImplHkdf(seed []byte, subnets []*phantomNet) (*phantomIP, error) {
+func selectPhantomImplHkdf(seed []byte, subnets []*phantomNet) (*PhantomIP, error) {
 	type idNet struct {
 		min, max big.Int
 		net      *phantomNet
@@ -519,7 +529,7 @@ func selectPhantomImplHkdf(seed []byte, subnets []*phantomNet) (*phantomIP, erro
 	// Find the network (ID net) that contains our random value and select a
 	// random address from that subnet.
 	// min >= id%total >= max
-	var result *phantomIP
+	var result *PhantomIP
 	for _, _idNet := range idNets {
 		// fmt.Printf("tot:%s, seed%%tot:%s     id cmp max: %d,  id cmp min: %d %s\n", addressTotal.String(), id, _idNet.max.Cmp(id), _idNet.min.Cmp(id), _idNet.net.String())
 		if _idNet.max.Cmp(id) >= 0 && _idNet.min.Cmp(id) <= 0 {
@@ -531,7 +541,7 @@ func selectPhantomImplHkdf(seed []byte, subnets []*phantomNet) (*phantomIP, erro
 				return nil, fmt.Errorf("failed to chose IP address: %v", err)
 			}
 
-			result = &phantomIP{IP: &res, supportRandomPort: _idNet.net.supportRandomPort}
+			result = &PhantomIP{IP: &res, SupportsPortRand: _idNet.net.supportRandomPort}
 		}
 	}
 

--- a/pkg/station/lib/phantom_selector.go
+++ b/pkg/station/lib/phantom_selector.go
@@ -35,16 +35,13 @@ var (
 // selected array of subnet strings based on the associated weights
 //
 // Used by Client version 0 and 1
-func (sc *SubnetConfig) getSubnetsVarint(seed []byte, weighted bool) []string {
-
-	var out []string = []string{}
+func (sc *SubnetConfig) getSubnetsVarint(seed []byte, weighted bool) ([]*phantomNet, error) {
 
 	if weighted {
 		// seed random with hkdf derived seed provided by client
 		seedInt, n := binary.Varint(seed)
 		if n == 0 {
-			fmt.Println("failed to seed random for weighted rand")
-			return nil
+			return nil, fmt.Errorf("failed to seed random for weighted rand")
 		}
 
 		// nolint:staticcheck // here for backwards compatibility with clients
@@ -52,23 +49,28 @@ func (sc *SubnetConfig) getSubnetsVarint(seed []byte, weighted bool) []string {
 
 		choices := make([]wr.Choice, 0, len(sc.WeightedSubnets))
 		for _, cjSubnet := range sc.WeightedSubnets {
-			choices = append(choices, wr.Choice{Item: cjSubnet.Subnets, Weight: uint(cjSubnet.Weight)})
+			choices = append(choices, wr.Choice{Item: &cjSubnet, Weight: uint(cjSubnet.Weight)})
 		}
 		c, err := wr.NewChooser(choices...)
 		if err != nil {
-			return out
+			return nil, err
 		}
 
-		out = c.Pick().([]string)
-	} else {
+		return parseSubnets(c.Pick().(*ConjurePhantomSubnet))
 
-		// Use unweighted config for subnets, concat all into one array and return.
-		for _, cjSubnet := range sc.WeightedSubnets {
-			out = append(out, cjSubnet.Subnets...)
-		}
 	}
 
-	return out
+	// Use unweighted config for subnets, concat all into one array and return.
+	out := []*phantomNet{}
+	for _, cjSubnet := range sc.WeightedSubnets {
+		nets, err := parseSubnets(&cjSubnet)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing subnet: %v", err)
+		}
+		out = append(out, nets...)
+	}
+
+	return out, nil
 }
 
 // getSubnetsHkdf returns EITHER all subnet strings as one composite array if
@@ -78,23 +80,15 @@ func (sc *SubnetConfig) getSubnetsVarint(seed []byte, weighted bool) []string {
 // math/rand and varint.
 //
 // Used by Client version 2+
-func (sc *SubnetConfig) getSubnetsHkdf(seed []byte, weighted bool) []string {
+func (sc *SubnetConfig) getSubnetsHkdf(seed []byte, weighted bool) ([]*phantomNet, error) {
 
-	type Choice struct {
-		Subnets []string
-		Weight  int64
+	weightedSubnets := sc.WeightedSubnets
+	if weightedSubnets == nil {
+		return []*phantomNet{}, nil
 	}
 
-	var out []string = []string{}
-
 	if weighted {
-
-		weightedSubnets := sc.WeightedSubnets
-		if weightedSubnets == nil {
-			return []string{}
-		}
-
-		choices := make([]Choice, 0, len(weightedSubnets))
+		choices := make([]*ConjurePhantomSubnet, 0, len(weightedSubnets))
 
 		totWeight := int64(0)
 		for _, cjSubnet := range weightedSubnets {
@@ -105,7 +99,7 @@ func (sc *SubnetConfig) getSubnetsHkdf(seed []byte, weighted bool) []string {
 			}
 
 			totWeight += int64(weight)
-			choices = append(choices, Choice{Subnets: subnets, Weight: int64(weight)})
+			choices = append(choices, &cjSubnet)
 		}
 
 		// Sort choices assending
@@ -118,32 +112,31 @@ func (sc *SubnetConfig) getSubnetsHkdf(seed []byte, weighted bool) []string {
 		totWeightBig := big.NewInt(totWeight)
 		rndBig, err := rand.Int(hkdfReader, totWeightBig)
 		if err != nil {
-			return nil
+			return nil, err
 		}
 
 		// Decrement rnd by each weight until it's < 0
 		rnd := rndBig.Int64()
 		for _, choice := range choices {
-			rnd -= choice.Weight
+			rnd -= int64(choice.Weight)
 			if rnd < 0 {
-				return choice.Subnets
+				return parseSubnets(choice)
 			}
 		}
 
-	} else {
-
-		weightedSubnets := sc.WeightedSubnets
-		if weightedSubnets == nil {
-			return []string{}
-		}
-
-		// Use unweighted config for subnets, concat all into one array and return.
-		for _, cjSubnet := range weightedSubnets {
-			out = append(out, cjSubnet.Subnets...)
-		}
 	}
 
-	return out
+	// Use unweighted config for subnets, concat all into one array and return.
+	out := []*phantomNet{}
+	for _, cjSubnet := range weightedSubnets {
+		nets, err := parseSubnets(&cjSubnet)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing subnet: %v", err)
+		}
+		out = append(out, nets...)
+	}
+
+	return out, nil
 }
 
 // SubnetFilter - Filter IP subnets based on whatever to prevent specific
@@ -151,8 +144,8 @@ func (sc *SubnetConfig) getSubnetsHkdf(seed []byte, weighted bool) []string {
 type SubnetFilter func([]*net.IPNet) ([]*net.IPNet, error)
 
 // V4Only - a functor for transforming the subnet list to only include IPv4 subnets
-func V4Only(obj []*net.IPNet) ([]*net.IPNet, error) {
-	var out []*net.IPNet = []*net.IPNet{}
+func V4Only(obj []*phantomNet) ([]*phantomNet, error) {
+	out := []*phantomNet{}
 
 	for _, _net := range obj {
 		if ipv4net := _net.IP.To4(); ipv4net != nil {
@@ -178,14 +171,14 @@ func V6Only(obj []*net.IPNet) ([]*net.IPNet, error) {
 	return out, nil
 }
 
-func parseSubnets(phantomSubnets []string) ([]*net.IPNet, error) {
-	var subnets []*net.IPNet = []*net.IPNet{}
+func parseSubnets(phantomSubnets *ConjurePhantomSubnet) ([]*phantomNet, error) {
+	subnets := []*phantomNet{}
 
-	if len(phantomSubnets) == 0 {
+	if len(phantomSubnets.Subnets) == 0 {
 		return nil, fmt.Errorf("parseSubnets - no subnets provided")
 	}
 
-	for _, strNet := range phantomSubnets {
+	for _, strNet := range phantomSubnets.Subnets {
 		_, parsedNet, err := net.ParseCIDR(strNet)
 		if err != nil {
 			return nil, err
@@ -194,11 +187,10 @@ func parseSubnets(phantomSubnets []string) ([]*net.IPNet, error) {
 			return nil, fmt.Errorf("failed to parse %v as subnet", parsedNet)
 		}
 
-		subnets = append(subnets, parsedNet)
+		subnets = append(subnets, &phantomNet{IPNet: parsedNet, supportRandomPort: phantomSubnets.RandomizeDstPort})
 	}
 
 	return subnets, nil
-	// return nil, fmt.Errorf("parseSubnets not implemented yet")
 }
 
 // NewPhantomIPSelector - create object currently populated with a static map of
@@ -208,24 +200,37 @@ func NewPhantomIPSelector() (*PhantomIPSelector, error) {
 	return GetPhantomSubnetSelector()
 }
 
+type phantomIP struct {
+	*net.IP
+	supportRandomPort bool
+}
+
+type phantomNet struct {
+	*net.IPNet
+	supportRandomPort bool
+}
+
+func subnetsByVersion(seed []byte, clientLibVer uint, genConfig *SubnetConfig) ([]*phantomNet, error) {
+
+	if clientLibVer < phantomHkdfMinVersion {
+		// Version 0 or 1
+		return genConfig.getSubnetsVarint(seed, true)
+	} else {
+		// Version 2
+		return genConfig.getSubnetsHkdf(seed, true)
+	}
+
+}
+
 // Select - select an ip address from the list of subnets associated with the specified generation
-func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer uint, v6Support bool) (net.IP, error) {
+func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer uint, v6Support bool) (*phantomIP, error) {
 
 	genConfig := p.GetSubnetsByGeneration(generation)
 	if genConfig == nil {
 		return nil, fmt.Errorf("generation number not recognized")
 	}
 
-	var genSubnetStrings []string
-	if clientLibVer < phantomHkdfMinVersion {
-		// Version 0 or 1
-		genSubnetStrings = genConfig.getSubnetsVarint(seed, true)
-	} else {
-		// Version 2
-		genSubnetStrings = genConfig.getSubnetsHkdf(seed, true)
-	}
-
-	genSubnets, err := parseSubnets(genSubnetStrings)
+	genSubnets, err := subnetsByVersion(seed, clientLibVer, genConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +245,12 @@ func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer ui
 	// handle legacy clientLibVersions for selecting phantoms.
 	if clientLibVer < phantomSelectionMinGeneration {
 		// Version 0
-		return selectPhantomImplV0(seed, genSubnets)
+		ip, err := selectPhantomImplV0(seed, genSubnets)
+		if err != nil {
+			return nil, err
+		}
+
+		return ip, nil
 	} else if clientLibVer < phantomHkdfMinVersion {
 		// Version 1
 		return selectPhantomImplVarint(seed, genSubnets)
@@ -255,10 +265,10 @@ func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer ui
 // end values for the high and low values in each allocation. The random number
 // is then bound between the global min and max of that set. This ensures that
 // addresses are chosen based on the number of addresses in the subnet.
-func selectPhantomImplVarint(seed []byte, subnets []*net.IPNet) (net.IP, error) {
+func selectPhantomImplVarint(seed []byte, subnets []*phantomNet) (*phantomIP, error) {
 	type idNet struct {
 		min, max big.Int
-		net      net.IPNet
+		net      *phantomNet
 	}
 	var idNets []idNet
 
@@ -272,14 +282,14 @@ func selectPhantomImplVarint(seed []byte, subnets []*net.IPNet) (net.IP, error) 
 			_idNet.min.Set(addressTotal)
 			addressTotal.Add(addressTotal, big.NewInt(2).Exp(big.NewInt(2), big.NewInt(int64(32-netMaskOnes)), nil))
 			_idNet.max.Sub(addressTotal, big.NewInt(1))
-			_idNet.net = *_net
+			_idNet.net = _net
 			idNets = append(idNets, _idNet)
 		} else if ipv6net := _net.IP.To16(); ipv6net != nil {
 			_idNet := idNet{}
 			_idNet.min.Set(addressTotal)
 			addressTotal.Add(addressTotal, big.NewInt(2).Exp(big.NewInt(2), big.NewInt(int64(128-netMaskOnes)), nil))
 			_idNet.max.Sub(addressTotal, big.NewInt(1))
-			_idNet.net = *_net
+			_idNet.net = _net
 			idNets = append(idNets, _idNet)
 		} else {
 			return nil, fmt.Errorf("failed to parse %v", _net)
@@ -302,15 +312,16 @@ func selectPhantomImplVarint(seed []byte, subnets []*net.IPNet) (net.IP, error) 
 	// Find the network (ID net) that contains our random value and select a
 	// random address from that subnet.
 	// min >= id%total >= max
-	var result net.IP
-	var err error
+	var result *phantomIP
 	for _, _idNet := range idNets {
 		// fmt.Printf("tot:%s, seed%%tot:%s     id cmp max: %d,  id cmp min: %d %s\n", addressTotal.String(), id, _idNet.max.Cmp(id), _idNet.min.Cmp(id), _idNet.net.String())
 		if _idNet.max.Cmp(id) >= 0 && _idNet.min.Cmp(id) <= 0 {
-			result, err = SelectAddrFromSubnet(seed, &_idNet.net)
+			res, err := SelectAddrFromSubnet(seed, _idNet.net.IPNet)
 			if err != nil {
 				return nil, fmt.Errorf("failed to chose IP address: %v", err)
 			}
+
+			result = &phantomIP{IP: &res, supportRandomPort: _idNet.net.supportRandomPort}
 		}
 	}
 
@@ -323,13 +334,13 @@ func selectPhantomImplVarint(seed []byte, subnets []*net.IPNet) (net.IP, error) 
 
 // selectPhantomImplV0 implements support for the legacy (buggy) client phantom
 // address selection algorithm.
-func selectPhantomImplV0(seed []byte, subnets []*net.IPNet) (net.IP, error) {
+func selectPhantomImplV0(seed []byte, subnets []*phantomNet) (*phantomIP, error) {
 
 	addressTotal := big.NewInt(0)
 
 	type idNet struct {
 		min, max big.Int
-		net      *net.IPNet
+		net      *phantomNet
 	}
 	var idNets []idNet
 
@@ -366,14 +377,14 @@ func selectPhantomImplV0(seed []byte, subnets []*net.IPNet) (net.IP, error) {
 		id.Mod(id, addressTotal)
 	}
 
-	var result net.IP
-	var err error
+	var result *phantomIP
 	for _, _idNet := range idNets {
 		if _idNet.max.Cmp(id) >= 0 && _idNet.min.Cmp(id) == -1 {
-			result, err = SelectAddrFromSubnet(seed, _idNet.net)
+			res, err := SelectAddrFromSubnet(seed, _idNet.net.IPNet)
 			if err != nil {
 				return nil, fmt.Errorf("failed to chose IP address: %v", err)
 			}
+			result = &phantomIP{IP: &res, supportRandomPort: _idNet.net.supportRandomPort}
 		}
 	}
 	if result == nil {
@@ -461,10 +472,10 @@ func SelectAddrFromSubnetOffset(net1 *net.IPNet, offset *big.Int) (net.IP, error
 // end values for the high and low values in each allocation. The random number
 // is then bound between the global min and max of that set. This ensures that
 // addresses are chosen based on the number of addresses in the subnet.
-func selectPhantomImplHkdf(seed []byte, subnets []*net.IPNet) (net.IP, error) {
+func selectPhantomImplHkdf(seed []byte, subnets []*phantomNet) (*phantomIP, error) {
 	type idNet struct {
 		min, max big.Int
-		net      net.IPNet
+		net      *phantomNet
 	}
 	var idNets []idNet
 
@@ -478,14 +489,14 @@ func selectPhantomImplHkdf(seed []byte, subnets []*net.IPNet) (net.IP, error) {
 			_idNet.min.Set(addressTotal)
 			addressTotal.Add(addressTotal, big.NewInt(2).Exp(big.NewInt(2), big.NewInt(int64(32-netMaskOnes)), nil))
 			_idNet.max.Sub(addressTotal, big.NewInt(1))
-			_idNet.net = *_net
+			_idNet.net = _net
 			idNets = append(idNets, _idNet)
 		} else if ipv6net := _net.IP.To16(); ipv6net != nil {
 			_idNet := idNet{}
 			_idNet.min.Set(addressTotal)
 			addressTotal.Add(addressTotal, big.NewInt(2).Exp(big.NewInt(2), big.NewInt(int64(128-netMaskOnes)), nil))
 			_idNet.max.Sub(addressTotal, big.NewInt(1))
-			_idNet.net = *_net
+			_idNet.net = _net
 			idNets = append(idNets, _idNet)
 		} else {
 			return nil, fmt.Errorf("failed to parse %v", _net)
@@ -508,17 +519,19 @@ func selectPhantomImplHkdf(seed []byte, subnets []*net.IPNet) (net.IP, error) {
 	// Find the network (ID net) that contains our random value and select a
 	// random address from that subnet.
 	// min >= id%total >= max
-	var result net.IP
+	var result *phantomIP
 	for _, _idNet := range idNets {
 		// fmt.Printf("tot:%s, seed%%tot:%s     id cmp max: %d,  id cmp min: %d %s\n", addressTotal.String(), id, _idNet.max.Cmp(id), _idNet.min.Cmp(id), _idNet.net.String())
 		if _idNet.max.Cmp(id) >= 0 && _idNet.min.Cmp(id) <= 0 {
 
 			var offset big.Int
 			offset.Sub(id, &_idNet.min)
-			result, err = SelectAddrFromSubnetOffset(&_idNet.net, &offset)
+			res, err := SelectAddrFromSubnetOffset(_idNet.net.IPNet, &offset)
 			if err != nil {
 				return nil, fmt.Errorf("failed to chose IP address: %v", err)
 			}
+
+			result = &phantomIP{IP: &res, supportRandomPort: _idNet.net.supportRandomPort}
 		}
 	}
 

--- a/pkg/station/lib/phantoms.go
+++ b/pkg/station/lib/phantoms.go
@@ -10,8 +10,9 @@ import (
 
 // ConjurePhantomSubnet - Weighted option to choose phantom address from.
 type ConjurePhantomSubnet struct {
-	Weight  uint32
-	Subnets []string
+	Weight           uint32
+	Subnets          []string
+	RandomizeDstPort bool
 }
 
 // SubnetConfig - Configuration of subnets for Conjure to choose a Phantom out of.

--- a/pkg/station/lib/phantoms_test.go
+++ b/pkg/station/lib/phantoms_test.go
@@ -19,5 +19,7 @@ func TestPhantomsParse(t *testing.T) {
 	require.Equal(t, ok, true)
 	require.Equal(t, len(sc.WeightedSubnets), 2)
 	require.Equal(t, len(sc.WeightedSubnets[0].Subnets), 2)
+	require.True(t, sc.WeightedSubnets[0].RandomizeDstPort)
+	require.False(t, sc.WeightedSubnets[1].RandomizeDstPort)
 	require.Contains(t, sc.WeightedSubnets[0].Subnets, "192.122.190.0/24")
 }

--- a/pkg/station/lib/registration_ingest_test.go
+++ b/pkg/station/lib/registration_ingest_test.go
@@ -79,7 +79,7 @@ func TestIngestPortHandlingFunctionality(t *testing.T) {
 	seed, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
 
 	for _, testCase := range goodCases {
-		port, err := rm.getPhantomDstPort(testCase.t, testCase.p, seed, testCase.v)
+		port, err := rm.getPhantomDstPort(testCase.t, testCase.p, seed, testCase.v, true)
 		require.Nil(t, err)
 		require.Equal(t, testCase.expected, port, "case: %v", testCase)
 	}
@@ -115,7 +115,7 @@ func TestIngestPortHandlingCorners(t *testing.T) {
 	seed, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
 
 	for _, testCase := range cases {
-		_, err := rm.getPhantomDstPort(testCase.t, testCase.p, seed, testCase.v)
+		_, err := rm.getPhantomDstPort(testCase.t, testCase.p, seed, testCase.v, true)
 		require.NotNil(t, err, "case: %v", testCase)
 		require.Equal(t, testCase.err, err.Error(), "case: %v", testCase)
 	}

--- a/pkg/station/lib/test/phantom_subnets.toml
+++ b/pkg/station/lib/test/phantom_subnets.toml
@@ -17,7 +17,9 @@
         Generation = 957
         [[Networks.957.WeightedSubnets]]
             Weight = 9
+            RandomizeDstPort = true
             Subnets = ["192.122.190.0/24", "2001:48a8:687f:1::/64"] 
         [[Networks.957.WeightedSubnets]]
             Weight = 1
+            RandomizeDstPort = false
             Subnets = ["141.219.0.0/16", "35.8.0.0/16"] 


### PR DESCRIPTION
Follow up to #208 so that station side also checks port randomization instead of just reading from registration. 