### PR TITLE
Bug Hunting in v0.7.x

### DIFF
--- a/pkg/transports/wrapping/prefix/prefix_test.go
+++ b/pkg/transports/wrapping/prefix/prefix_test.go
@@ -6,8 +6,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
+	"net"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/curve25519"
@@ -64,11 +66,10 @@ func TestSuccessfulWrap(t *testing.T) {
 				require.Nil(t, err)
 
 				var buf [4096]byte
-				var buffer bytes.Buffer
 				n, _ := sfp.Read(buf[:])
-				buffer.Write(buf[:n])
+				buffer := bytes.NewBuffer(buf[:n])
 
-				_, wrapped, err := transport.WrapConnection(&buffer, sfp, reg.PhantomIp, manager)
+				_, wrapped, err := transport.WrapConnection(buffer, sfp, reg.PhantomIp, manager)
 				if id != idx {
 					require.ErrorIs(t, err, ErrIncorrectPrefix)
 					continue
@@ -399,3 +400,80 @@ func TestSuccessfulWrapBase64(t *testing.T) {
 
 }
 */
+
+// Test End to End client WrapConn to Server WrapConnection
+func TestPrefixEndToEnd(t *testing.T) {
+	testSubnetPath := conjurepath.Root + "/pkg/station/lib/test/phantom_subnets.toml"
+	os.Setenv("PHANTOM_SUBNET_LOCATION", testSubnetPath)
+
+	_, private, _ := ed25519.GenerateKey(rand.Reader)
+
+	var curve25519Public, curve25519Private [32]byte
+	extra25519.PrivateKeyToCurve25519(&curve25519Private, private)
+	curve25519.ScalarBaseMult(&curve25519Public, &curve25519Private)
+
+	var transport = Transport{
+		TagObfuscator:     transports.CTRObfuscator{},
+		Privkey:           curve25519Private,
+		SupportedPrefixes: defaultPrefixes,
+	}
+	message := []byte(`test message!`)
+
+	for _, flushPolicy := range []int32{DefaultFlush, NoAddedFlush, FlushAfterPrefix} {
+		for idx := range defaultPrefixes {
+
+			t.Logf("testing prefix %d, %s", idx, idx.Name())
+
+			var p int32 = int32(idx)
+			params := &pb.PrefixTransportParams{PrefixId: &p, CustomFlushPolicy: &flushPolicy}
+			manager := tests.SetupRegistrationManager(tests.Transport{Index: pb.TransportType_Prefix, Transport: transport})
+			c2p, sfp, reg := tests.SetupPhantomConnections(manager, pb.TransportType_Prefix, params, uint(core.CurrentClientLibraryVersion()))
+			defer c2p.Close()
+			defer sfp.Close()
+			require.NotNil(t, reg)
+
+			go func() {
+
+				var c net.Conn
+				var err error
+				var buf [4096]byte
+				for {
+					n, _ := sfp.Read(buf[:])
+					// t.Logf("%d %s\t %s", n, hex.EncodeToString(buf[:n]), string(buf[:n]))
+					buffer := bytes.NewBuffer(buf[:n])
+					_, c, err = transport.WrapConnection(buffer, sfp, reg.PhantomIp, manager)
+					if err == nil {
+						break
+					} else if !errors.Is(err, transports.ErrTryAgain) {
+						t.Errorf("error getting wrapped connection %s", err)
+						return
+					}
+				}
+
+				received := make([]byte, len(message))
+				_, err = io.ReadFull(c, received)
+				require.Nil(t, err, "failed reading from server connection")
+				_, err = c.Write(received)
+				require.Nil(t, err, "failed writing to server connection")
+			}()
+
+			clientPrefix, err := TryFromID(PrefixID(p))
+			require.Nil(t, err)
+			ClientTransport := &ClientTransport{Prefix: clientPrefix, parameters: params}
+			err = ClientTransport.PrepareKeys(curve25519Public, reg.Keys.SharedSecret, reg.Keys.TransportReader)
+			require.Nil(t, err)
+			clientConn, err := ClientTransport.WrapConn(c2p)
+			require.Nil(t, err, "error getting wrapped connection")
+
+			err = clientConn.SetDeadline(time.Now().Add(3 * time.Second))
+			require.Nil(t, err, "error setting deadline")
+
+			_, err = clientConn.Write(message)
+			require.Nil(t, err, "failed writing to client connection")
+			cbuf := make([]byte, len(message))
+			_, err = io.ReadFull(clientConn, cbuf)
+			require.Nil(t, err, "failed reading from client connection")
+			require.True(t, bytes.Equal(message, cbuf), "%s\n%s", string(message), string(cbuf))
+		}
+	}
+}


### PR DESCRIPTION
Multiple fixes to errors introduced in `v0.7.X`.
- [x] protobuf pointer deref instead of getter
- [x] prefix transport writing to `bufio.Writer` without an explicit call to `Flush()`
    - resulted in prefix and tag not being written at all.
- [x] ~Maybe Key generation inconsistencies / `core.GetCurrentVersion` issues~