### PR TITLE
Update aes-gcm dependency to satisfy a dependabot alert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["rlib", "staticlib"]
 toml = "0.7"
 serde = {version="1.0", features=["derive"]}
 libc = "0.2"
-aes-gcm = { version="0.10", features=["aes"]}
+aes-gcm = { version="^0.10.3", features=["aes"]}
 time = {version="0.3.28", features=["macros", "formatting", "local-offset"]} 
 pnet = "0.33"
 arrayref = "0.3"


### PR DESCRIPTION
Solution for:
https://github.com/refraction-networking/conjure/security/dependabot/9