### PR TITLE
API Registration Source Fix

### DIFF
--- a/pkg/regserver/regprocessor/regprocessor.go
+++ b/pkg/regserver/regprocessor/regprocessor.go
@@ -380,12 +380,6 @@ func (p *RegProcessor) processC2SWrapper(c2sPayload *pb.C2SWrapper, clientAddr [
 	// in the C2SWrapper set it here as the source.
 	if c2sPayload.GetRegistrationSource() == pb.RegistrationSource_Unspecified {
 		source := regMethod
-
-		// Do not distinguish between API and bidirectional API
-		if source == pb.RegistrationSource_BidirectionalAPI {
-			source = pb.RegistrationSource_API
-		}
-
 		payload.RegistrationSource = &source
 	} else {
 		source := c2sPayload.GetRegistrationSource()


### PR DESCRIPTION
This PR fixes a small bookkeeping error that labels all API registrations as API, whether they are bidirectional or not. This hinders some of the performance stats tracking.


The simple fix was to remove a line that relabels bidirectional API registrations as plain API.