### PR TITLE
Rust protobuf dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rand = "0.8.5"
 errno = "0.3.1"
 tuntap = { git = "https://github.com/ewust/tuntap.rs" }
 ipnetwork = "0.20"
-protobuf = "3.2"
+protobuf = "3.2.*"
 hkdf = "0.12"
 sha2 = "0.10"
 hex = "0.4"


### PR DESCRIPTION
the pattern match for rust `Cargo.toml` dependencies  allows use of protobuf `3.3.0` which has breaking API changes.


`3.2` matches `>=  3.2.0` up to `< 4.0.0` -- however version `3.3.0` has breaking API changes so using this dependency wont work.

instead match `3.2.*` which is anything between `>=3.2.0` and `< 3.3.0`