### PR TITLE
Port Randomization follow-up fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/pion/stun v0.6.1
 	github.com/pion/transport/v2 v2.2.3
 	github.com/refraction-networking/ed25519 v0.1.2
-	github.com/refraction-networking/gotapdance v1.7.5-0.20231007192233-6c0352155207
+	github.com/refraction-networking/gotapdance v1.7.5-0.20231008035356-980b28fc1555
 	github.com/refraction-networking/obfs4 v0.1.2
 	github.com/refraction-networking/utls v1.3.3
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/refraction-networking/ed25519 v0.1.2 h1:08kJZUkAlY7a7cZGosl1teGytV+QEoNxPO7NnRvAB+g=
 github.com/refraction-networking/ed25519 v0.1.2/go.mod h1:nxYLUAYt/hmNpAh64PNSQ/tQ9gTIB89wCaGKJlRtZ9I=
-github.com/refraction-networking/gotapdance v1.7.5-0.20231007192233-6c0352155207 h1:j13eRL4998NZSroZyz5E795cCQj2E/USmHLot+nr+G8=
-github.com/refraction-networking/gotapdance v1.7.5-0.20231007192233-6c0352155207/go.mod h1:w40UUCQH18Z2pWVLAGqj6L9d3t3YpAhW4w5r0YgGptY=
+github.com/refraction-networking/gotapdance v1.7.5-0.20231008035356-980b28fc1555 h1:k1s1Uz+GiAn/6qUdQt8NmrZLe9O2QxZ8CdqC/d71qdk=
+github.com/refraction-networking/gotapdance v1.7.5-0.20231008035356-980b28fc1555/go.mod h1:ReFEvrTygB7w64WU380mcKB9+IDekqepWdfAA5yIbng=
 github.com/refraction-networking/obfs4 v0.1.2 h1:J842O4fGSkd2W8ogYj0KN6gqVVY+Cpqodw9qFGL7wVU=
 github.com/refraction-networking/obfs4 v0.1.2/go.mod h1:wAl/+gWiLsrcykJA3nKJHx89f5/gXGM8UKvty7+mvbM=
 github.com/refraction-networking/utls v1.3.3 h1:f/TBLX7KBciRyFH3bwupp+CE4fzoYKCirhdRcC490sw=

--- a/internal/port_integration_test.go
+++ b/internal/port_integration_test.go
@@ -1,0 +1,120 @@
+package integration_test
+
+import (
+	"context"
+	"crypto/rand"
+	"os"
+	"testing"
+
+	"github.com/refraction-networking/conjure/internal/conjurepath"
+	"github.com/refraction-networking/conjure/internal/testutils"
+	"github.com/refraction-networking/conjure/pkg/core"
+	"github.com/refraction-networking/conjure/pkg/core/interfaces"
+	"github.com/refraction-networking/conjure/pkg/station/log"
+	pb "github.com/refraction-networking/conjure/proto"
+	"github.com/refraction-networking/ed25519"
+	"github.com/refraction-networking/ed25519/extra25519"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/curve25519"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func TestBase(T *testing.T) {
+	T.Run("TestBase", func(T *testing.T) {
+		require.Equal(T, 1, 1)
+	})
+}
+
+func TestTransportPortSelection(t *testing.T) {
+	if *debug {
+		log.SetLevel(log.DebugLevel)
+	}
+
+	var testCases = getTestCases(t)
+	for _, testCase := range testCases {
+		t.Run(testCase.clientTransport.Name(), func(t *testing.T) {
+			testTransportPortSelection(t, testCase.stationTransportBuilder, testCase.clientTransport, testCase.clientParamPermuteGenerator)
+		})
+	}
+}
+
+func testTransportPortSelection(t *testing.T, builder stationBuilder, clientTransport interfaces.WrappingTransport, clientParamPermuteGenerator func() []TestParams) {
+	testSubnetPath := conjurepath.Root + "/pkg/station/lib/test/phantom_subnets.toml"
+	os.Setenv("PHANTOM_SUBNET_LOCATION", testSubnetPath)
+	libver := uint(core.CurrentClientLibraryVersion())
+
+	_, private, _ := ed25519.GenerateKey(rand.Reader)
+
+	var curve25519Public, curve25519Private [32]byte
+	extra25519.PrivateKeyToCurve25519(&curve25519Private, private)
+	curve25519.ScalarBaseMult(&curve25519Public, &curve25519Private)
+
+	transport := builder(curve25519Private)
+	transportType := clientTransport.ID()
+
+	// Ensure that we test all given parameter permutations as well as nil params
+	paramSet := append([]TestParams{nil}, clientParamPermuteGenerator()...)
+
+	for _, testParams := range paramSet {
+		if testParams == nil {
+			testParams = &nilParams{}
+		}
+		params := testParams.GetParams()
+		clientKeys, err := core.GenerateClientSharedKeys(curve25519Public)
+		require.Nil(t, err)
+
+		err = clientTransport.SetParams(params)
+		require.Nil(t, err)
+
+		// ensure that if the registration w/ transport config is re-used then the selected port is
+		// still consistent between the client and server.
+		for i := 0; i < 10; i++ {
+
+			err = clientTransport.Prepare(context.Background(), nil)
+			require.Nil(t, err)
+
+			protoParams, err := clientTransport.GetParams()
+			require.Nil(t, err)
+			log.Debugf("running %s w/ %s", clientTransport.Name(), testParams.String())
+
+			manager := testutils.SetupRegistrationManager(testutils.Transport{Index: pb.TransportType_Prefix, Transport: transport})
+			require.NotNil(t, manager)
+
+			v := uint32(libver)
+			covert := "1.2.3.4:56789"
+			regType := pb.RegistrationSource_API
+			gen := uint32(1)
+			c2s := &pb.ClientToStation{
+				ClientLibVersion:    &v,
+				Transport:           &transportType,
+				CovertAddress:       &covert,
+				DecoyListGeneration: &gen,
+			}
+			if params != nil {
+				p, err := anypb.New(protoParams)
+				if err != nil {
+					log.Fatalln("failed to make params", err)
+				}
+				c2s.TransportParams = p
+			}
+
+			keys, err := core.GenSharedKeys(libver, clientKeys.SharedSecret, transportType)
+			if err != nil {
+				log.Fatalln("failed to generate shared keys:", err)
+			}
+
+			reg, err := manager.NewRegistration(c2s, &keys, false, &regType)
+			require.Nil(t, err, "failed to create new Registration")
+
+			reg.Transport = transportType
+
+			// Get the port that the client will connect to
+			clientPort, err := clientTransport.GetDstPort(clientKeys.ConjureSeed)
+			require.Nil(t, err, "failed to get client port")
+
+			serverPort := reg.PhantomPort
+			require.Equal(t, clientPort, serverPort, "c:%d != s:%d - %s %s", clientPort, serverPort, transport.Name(), testParams.String())
+			t.Logf("ports: c:%d, s:%d", clientPort, serverPort)
+		}
+	}
+}

--- a/internal/port_integration_test.go
+++ b/internal/port_integration_test.go
@@ -106,6 +106,7 @@ func testTransportPortSelection(t *testing.T, builder stationBuilder, clientTran
 			for _, v6Reg := range []bool{false, true} {
 				phantom, err := manager.PhantomSelector.Select(
 					clientKeys.ConjureSeed, uint(gen), libver, v6Reg)
+				require.Nil(t, err)
 
 				reg, err := manager.NewRegistration(c2s, &keys, v6Reg, &regType)
 				require.Nil(t, err, "failed to create new Registration")

--- a/internal/test_assets/phantom_subnets.toml
+++ b/internal/test_assets/phantom_subnets.toml
@@ -5,12 +5,14 @@
         Generation = 1
         [[Networks.1.WeightedSubnets]]
             Weight = 9
+            RandomizeDstPort = false
             Subnets = ["192.122.190.0/24", "2001:48a8:687f:1::/64"] 
 
     [Networks.2]
         Generation = 2
         [[Networks.2.WeightedSubnets]]
             Weight = 1
+            RandomizeDstPort = true
             Subnets = ["192.122.190.0/28", "2001:48a8:687f:1::/96"] 
 
     [Networks.957]

--- a/internal/transport_integration_test.go
+++ b/internal/transport_integration_test.go
@@ -57,15 +57,6 @@ func getTestCases(t *testing.T) []struct {
 	}{
 		{
 			func(privKey [32]byte) lib.WrappingTransport {
-				tr, err := prefix.Default(privKey)
-				require.Nil(t, err)
-				return tr
-			},
-			&prefix.ClientTransport{},
-			prefixClientParamPermutations,
-		},
-		{
-			func(privKey [32]byte) lib.WrappingTransport {
 				return &obfs4.Transport{}
 			},
 			&obfs4.ClientTransport{},
@@ -77,6 +68,15 @@ func getTestCases(t *testing.T) []struct {
 			},
 			&min.ClientTransport{},
 			genericParamPermutations,
+		},
+		{
+			func(privKey [32]byte) lib.WrappingTransport {
+				tr, err := prefix.Default(privKey)
+				require.Nil(t, err)
+				return tr
+			},
+			&prefix.ClientTransport{},
+			prefixClientParamPermutations,
 		},
 	}
 }

--- a/pkg/core/interfaces/interfaces.go
+++ b/pkg/core/interfaces/interfaces.go
@@ -49,7 +49,7 @@ type Transport interface {
 	Prepare(ctx context.Context, dialer func(ctx context.Context, network, laddr, raddr string) (net.Conn, error)) error
 
 	// GetDstPort returns the destination port that the client should open the phantom connection with.
-	GetDstPort(seed []byte, randomizeDstPorSupported bool) (uint16, error)
+	GetDstPort(seed []byte) (uint16, error)
 
 	// PrepareKeys provides an opportunity for the transport to integrate the station public key
 	// as well as bytes from the deterministic random generator associated with the registration

--- a/pkg/transports/connecting/dtls/client.go
+++ b/pkg/transports/connecting/dtls/client.go
@@ -195,8 +195,8 @@ func (*ClientTransport) DisableRegDelay() bool {
 }
 
 // GetDstPort returns the destination port that the client should open the phantom connection to
-func (t *ClientTransport) GetDstPort(seed []byte, phantomSubnetSupportsRandPort bool) (uint16, error) {
-	if t.Parameters == nil || !t.Parameters.GetRandomizeDstPort() || !phantomSubnetSupportsRandPort {
+func (t *ClientTransport) GetDstPort(seed []byte) (uint16, error) {
+	if t.Parameters == nil || !t.Parameters.GetRandomizeDstPort() {
 		return defaultPort, nil
 	}
 

--- a/pkg/transports/wrapping/min/client.go
+++ b/pkg/transports/wrapping/min/client.go
@@ -116,8 +116,8 @@ func (t *ClientTransport) SetParams(p any) error {
 }
 
 // GetDstPort returns the destination port that the client should open the phantom connection to
-func (t *ClientTransport) GetDstPort(seed []byte, phantomSubnetSupportsRandPort bool) (uint16, error) {
-	if t.sessionParams == nil || !t.sessionParams.GetRandomizeDstPort() || !phantomSubnetSupportsRandPort {
+func (t *ClientTransport) GetDstPort(seed []byte) (uint16, error) {
+	if t.sessionParams == nil || !t.sessionParams.GetRandomizeDstPort() {
 		return 443, nil
 	}
 

--- a/pkg/transports/wrapping/obfs4/client.go
+++ b/pkg/transports/wrapping/obfs4/client.go
@@ -118,8 +118,8 @@ func (t ClientTransport) ParseParams(data *anypb.Any) (any, error) {
 }
 
 // GetDstPort returns the destination port that the client should open the phantom connection to
-func (t *ClientTransport) GetDstPort(seed []byte, phantomSubnetSupportsRandPort bool) (uint16, error) {
-	if t.sessionParams == nil || !t.sessionParams.GetRandomizeDstPort() || !phantomSubnetSupportsRandPort {
+func (t *ClientTransport) GetDstPort(seed []byte) (uint16, error) {
+	if t.sessionParams == nil || !t.sessionParams.GetRandomizeDstPort() {
 		return 443, nil
 	}
 

--- a/pkg/transports/wrapping/prefix/client.go
+++ b/pkg/transports/wrapping/prefix/client.go
@@ -499,7 +499,7 @@ func pickRandomPrefix(r io.Reader) (Prefix, error) {
 }
 
 func (t *ClientTransport) debug(s string) {
-	if true {
+	if false {
 		fmt.Printf("%s - %+v\n\t%+v\n\t%+v\n", s, t.Prefix, t.parameters, t.sessionParams)
 	}
 }

--- a/pkg/transports/wrapping/prefix/client.go
+++ b/pkg/transports/wrapping/prefix/client.go
@@ -324,7 +324,7 @@ func (t *ClientTransport) SetParams(p any) error {
 }
 
 // GetDstPort returns the destination port that the client should open the phantom connection to
-func (t *ClientTransport) GetDstPort(seed []byte, randomizeDstPorSupported bool) (uint16, error) {
+func (t *ClientTransport) GetDstPort(seed []byte) (uint16, error) {
 
 	if t == nil {
 		return 0, ErrBadParams
@@ -345,7 +345,7 @@ func (t *ClientTransport) GetDstPort(seed []byte, randomizeDstPorSupported bool)
 		t.sessionParams = &pb.PrefixTransportParams{PrefixId: &p}
 	}
 
-	if t.sessionParams.GetRandomizeDstPort() && randomizeDstPorSupported {
+	if t.sessionParams.GetRandomizeDstPort() {
 		return transports.PortSelectorRange(portRangeMin, portRangeMax, seed)
 	}
 

--- a/pkg/transports/wrapping/prefix/prefix_test.go
+++ b/pkg/transports/wrapping/prefix/prefix_test.go
@@ -248,7 +248,7 @@ func TestPrefixGetDstPortClient(t *testing.T) {
 	ct := &ClientTransport{Prefix: DefaultPrefixes[0], parameters: nil}
 	err := ct.Prepare(context.Background(), nil)
 	require.Nil(t, err)
-	port, err := ct.GetDstPort(seed, true)
+	port, err := ct.GetDstPort(seed)
 	require.Nil(t, err)
 	require.Equal(t, uint16(443), port)
 
@@ -258,7 +258,7 @@ func TestPrefixGetDstPortClient(t *testing.T) {
 		require.Nil(t, err)
 
 		// check client get destination.
-		clientPort, err := ct.GetDstPort(seed, true)
+		clientPort, err := ct.GetDstPort(seed)
 		if testCase.e != nil {
 			require.ErrorIs(t, err, testCase.e, testCase.d)
 		} else {


### PR DESCRIPTION
1. undo unnecessary change to the internal `Transport` interface and ensure all subnets not supporting port randomization use the default port

2. Prefix transport selects the incorrect port for the chosen prefix id


In general I have been mentally conflating things that should generally be independent wrt. port randomization, the prefix transport, and the transport interface. For starters the prefix transport "port randomization" is not the same as the subnets "not supporting port randomization". The prefix transport (and really all of the transports that have their own "Randomize Destination Port" parameter) indicate user preferences indicated by the dialer. This was originally used for the min and obfs4 transports to enable port randomization. For the prefix transport using this parameter to "disable port randomization" means that the transport wont use a randomly generated port, but the original port specific to the prefix (i.e. 80 for HTTP, 443 for TLS, etc.). The only requirement for these types of parameters is that the station agrees / picks / generates the same port that the client is going to connect to. 

This is different than the phantom subnets that do not support port randomization which indicate that a station is only able to tap traffic on the original port. This may change in the future, but this has nothing to do with the transport interface. This means that any packets sent to a port other than the default will not be seen on the station so adherence to this requirement is not optional and cannot be overridden by any transport.