### PR TITLE
Minor Fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,13 @@ cc="^1.0.3"
 [lib]
 name = "rust_dark_decoy"
 crate-type = ["rlib", "staticlib"]
+
 [dependencies]
 toml = "0.7"
 serde = {version="1.0", features=["derive"]}
 libc = "0.2"
 aes-gcm = { version="^0.10.3", features=["aes"]}
-time = {version="0.3.28", features=["macros", "formatting", "local-offset"]} 
+time = {version="0.3.28", features=["macros", "formatting", "local-offset"]}
 pnet = "0.33"
 arrayref = "0.3"
 log = "0.4"

--- a/internal/port_integration_test.go
+++ b/internal/port_integration_test.go
@@ -19,12 +19,6 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
-func TestBase(T *testing.T) {
-	T.Run("TestBase", func(T *testing.T) {
-		require.Equal(T, 1, 1)
-	})
-}
-
 func TestTransportPortSelection(t *testing.T) {
 	if *debug {
 		log.SetLevel(log.DebugLevel)

--- a/scripts/start_zbalance_ipc.sh
+++ b/scripts/start_zbalance_ipc.sh
@@ -68,9 +68,9 @@ done
 
 # # Double output channel if N_QUEUE_SETS is set in config (used for two stations or TD + CJ)
 if [[ N_QUEUE_SETS = 1 ]]; then
-	echo "Setting up with params: -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE}"
-	zbalance_ipc -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE}
+	echo "Setting up with params: -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE} -d"
+	zbalance_ipc -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE} -d
 else
-	echo "Setting up with params: -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT},${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE}"
-	zbalance_ipc -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT},${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE}
+	echo "Setting up with params: -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT},${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE} -d"
+	zbalance_ipc -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT},${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE} -d
 fi


### PR DESCRIPTION
* Spelling mistakes
* fix un-moderated busy log loop that causes headaches logging when there are issues with redis. 
* remove superfluous test
* add `-d` option to zmq start script to indicate running as daemon, reducing logging.

proof of concept for rust logging backoff functor [rust-playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9b4833a5338521ae5dd52276b5f4872d)