### PR TITLE
Switch to using conjure-only assets to stop circular dependency

### DIFF
--- a/pkg/registrars/decoy-registrar/decoy-registrar_test.go
+++ b/pkg/registrars/decoy-registrar/decoy-registrar_test.go
@@ -122,7 +122,7 @@ func TestDecoyRegSendRegistration(t *testing.T) {
 	reg := NewDecoyRegistrar()
 	reg.Width = 1
 	reg.insecureSkipVerify = true
-	pubkey := td.Assets().GetConjurePubkey()
+	pubkey := assets.Assets().GetConjurePubkey()
 
 	keys, err := core.GenerateClientSharedKeys(*pubkey)
 	require.Nil(t, err)
@@ -213,7 +213,7 @@ func TestDecoyRegSendRegistration(t *testing.T) {
 	require.Equal(t, pb.TransportType_Min, stationC2S.GetTransport())
 	require.Equal(t, pb.TransportType_Min, stationC2S.GetTransport())
 	require.Equal(t, "1.1.1.1:443", stationC2S.GetCovertAddress())
-	require.Equal(t, td.Assets().GetGeneration(), stationC2S.GetDecoyListGeneration())
+	require.Equal(t, assets.Assets().GetGeneration(), stationC2S.GetDecoyListGeneration())
 }
 
 type catchReg struct {

--- a/pkg/registrars/decoy-registrar/utils.go
+++ b/pkg/registrars/decoy-registrar/utils.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/refraction-networking/conjure/pkg/client/assets"
 	"github.com/refraction-networking/conjure/pkg/core"
 	"github.com/refraction-networking/conjure/pkg/station/log"
 	pb "github.com/refraction-networking/conjure/proto"
@@ -220,7 +221,7 @@ func generateClientToStation(cjSession *td.ConjureSession) (*pb.ClientToStation,
 
 	//[reference] Generate ClientToStation protobuf
 	// transition := pb.C2S_Transition_C2S_SESSION_INIT
-	currentGen := td.Assets().GetGeneration()
+	currentGen := assets.Assets().GetGeneration()
 	currentLibVer := core.CurrentClientLibraryVersion()
 
 	if cjSession.Transport == nil {

--- a/pkg/registrars/registration/api-registrar_test.go
+++ b/pkg/registrars/registration/api-registrar_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/refraction-networking/conjure/pkg/client/assets"
 	transports "github.com/refraction-networking/conjure/pkg/transports/client"
 	pb "github.com/refraction-networking/conjure/proto"
 	"github.com/refraction-networking/gotapdance/tapdance"
@@ -24,7 +25,7 @@ func TestAPIRegistrar(t *testing.T) {
 	transport, err := transports.New("min")
 	require.Nil(t, err)
 
-	_, err = tapdance.AssetsSetDir("./tests/assets")
+	_, err = assets.AssetsSetDir("./tests/assets")
 	require.Nil(t, err)
 	session := tapdance.MakeConjureSession("1.2.3.4:1234", transport)
 


### PR DESCRIPTION
There's currently an assets.go in both this repo and the gotapdance one. The decoy-registrar (now living in this conjure repo) relies heavily on the conjure-based assets, which means the gotapdance client should also use that one (otherwise, any local changes the client makes to assets will be ignored when it uses the decoy-registrar).

However, there are still some vestigial references in this conjure repository for gotapdance assets. This PR fixes that, and exclusively uses the assets provided by conjure (`github.com/refraction-networking/conjure/pkg/client/assets`).