### PR TITLE
start zbalance as daemon with -d seems to break things -> switch to -z

### DIFF
--- a/scripts/start_zbalance_ipc.sh
+++ b/scripts/start_zbalance_ipc.sh
@@ -68,9 +68,9 @@ done
 
 # # Double output channel if N_QUEUE_SETS is set in config (used for two stations or TD + CJ)
 if [[ N_QUEUE_SETS = 1 ]]; then
-	echo "Setting up with params: -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE} -d"
-	zbalance_ipc -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE} -d
+	echo "Setting up with params: -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE} -z"
+	zbalance_ipc -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE} -z
 else
-	echo "Setting up with params: -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT},${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE} -d"
-	zbalance_ipc -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT},${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE} -d
+	echo "Setting up with params: -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT},${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE} -z"
+	zbalance_ipc -i $ifcarg -c ${CJ_CLUSTER_ID} -n ${CJ_CORECOUNT},${CJ_CORECOUNT} -m ${ZBALANCE_HASH_MODE} -g ${CJ_COREBASE} -z
 fi


### PR DESCRIPTION
It seems like running zbalance in daemon mode using the `-d` option does not do what I thought it would do. However, the `-z` option is the [proc_stats_only option](https://github.com/ntop/PF_RING/blob/434ff5b2d6c2e701aa9429f5266337c99764a541/userland/examples_zc/zbalance_ipc.c#L1193) which reduces the lines logged by zbalance, which we are not currently using anyways as we have a packet counter in the detector.