### PR TITLE
Registration ingest ToC-ToU race wasting resources 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/pion/stun v0.6.1
 	github.com/pion/transport/v2 v2.2.3
 	github.com/refraction-networking/ed25519 v0.1.2
-	github.com/refraction-networking/gotapdance v1.7.5-0.20231008035356-980b28fc1555
+	github.com/refraction-networking/gotapdance v1.7.7
 	github.com/refraction-networking/obfs4 v0.1.2
 	github.com/refraction-networking/utls v1.3.3
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/refraction-networking/ed25519 v0.1.2 h1:08kJZUkAlY7a7cZGosl1teGytV+QEoNxPO7NnRvAB+g=
 github.com/refraction-networking/ed25519 v0.1.2/go.mod h1:nxYLUAYt/hmNpAh64PNSQ/tQ9gTIB89wCaGKJlRtZ9I=
-github.com/refraction-networking/gotapdance v1.7.5-0.20231008035356-980b28fc1555 h1:k1s1Uz+GiAn/6qUdQt8NmrZLe9O2QxZ8CdqC/d71qdk=
-github.com/refraction-networking/gotapdance v1.7.5-0.20231008035356-980b28fc1555/go.mod h1:ReFEvrTygB7w64WU380mcKB9+IDekqepWdfAA5yIbng=
+github.com/refraction-networking/gotapdance v1.7.7 h1:RSdDCA0v4n/iIxCnxLF6uCoJdlo000R+IKGvELfpc/A=
+github.com/refraction-networking/gotapdance v1.7.7/go.mod h1:KORLtX2tKFXb2YDhynsQmGcLmmAHW20CVvdhP5kuAFA=
 github.com/refraction-networking/obfs4 v0.1.2 h1:J842O4fGSkd2W8ogYj0KN6gqVVY+Cpqodw9qFGL7wVU=
 github.com/refraction-networking/obfs4 v0.1.2/go.mod h1:wAl/+gWiLsrcykJA3nKJHx89f5/gXGM8UKvty7+mvbM=
 github.com/refraction-networking/utls v1.3.3 h1:f/TBLX7KBciRyFH3bwupp+CE4fzoYKCirhdRcC490sw=

--- a/pkg/station/lib/registration.go
+++ b/pkg/station/lib/registration.go
@@ -227,6 +227,13 @@ func (regManager *RegistrationManager) AddRegistration(d *DecoyRegistration) {
 	}
 }
 
+// RegistrationExists checks if the registration is already tracked by the manager, this is
+// independent of the validity tag, this just checks to see if the registration exists.
+func (regManager *RegistrationManager) RegistrationExists(reg *DecoyRegistration) bool {
+	trackedReg := regManager.registeredDecoys.RegistrationExists(reg)
+	return trackedReg != nil
+}
+
 // GetRegistrations returns registrations associated with a specific phantom address.
 func (regManager *RegistrationManager) GetRegistrations(phantomAddr net.IP) map[string]transports.Registration {
 	regs := regManager.registeredDecoys.getRegistrations(phantomAddr)
@@ -671,6 +678,14 @@ func (r *RegisteredDecoys) getRegistrations(darkDecoyAddr net.IP) map[string]*De
 	}
 
 	return regs
+}
+
+// RegistrationExists - For use outside of this struct only (so there are no data races.)
+func (r *RegisteredDecoys) RegistrationExists(d *DecoyRegistration) *DecoyRegistration {
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	return r.registrationExists(d)
 }
 
 // TotalRegistrations return the total number of current registrations

--- a/pkg/station/lib/registration_test.go
+++ b/pkg/station/lib/registration_test.go
@@ -56,11 +56,11 @@ func TestRegistrationLookup(t *testing.T) {
 	}
 	t.Log(newReg)
 
-	if rm.RegistrationExists(newReg) {
+	if rm.registeredDecoys.registrationExists(newReg) != nil {
 		t.Fatalf("Registration exists, but shouldn't")
 	}
 	rm.AddRegistration(newReg)
-	if !rm.RegistrationExists(newReg) {
+	if rm.registeredDecoys.registrationExists(newReg) == nil {
 		t.Fatalf("Registration should exist, but doesn't")
 	}
 }


### PR DESCRIPTION
In the registration ingest pipeline we check if the incoming registration has been seen before, as it is possible with certain registrars that more than one registration are seen for a single connection. 

In order to do so we track all seen registrations in the registration manager and check against the state when a new registration is received. 

---

**Issue:** By necessity the ingest pipeline is multi-threaded. This means that two registrations can be in the ingest pipeline simultaneously. The Time-of-Check to Time-of-Use error happens because there the step that checks whether a registration has been seen before and the step that adds the registration to the registration managers state are independent. This means that registrations being ingested in parallel could both pass the `RegistrationExists` step
and continue through to the end of the pipeline. There isn't any issue with correctness when this happens, but we waste a liveness test and a redis message.

**Fix:** This PR combines the two steps (check for existence and tracking the incoming registration) into one step
protected by the registration manager's internal mutex lock. So it is no longer possible to have more than one registration per connection transit the entire ingest pipeline, even if they show up at the same time in separate threads.