### PR TITLE
Alternate fix for oob slice creation in proxy halfpipe

### DIFF
--- a/pkg/station/lib/proxies.go
+++ b/pkg/station/lib/proxies.go
@@ -156,7 +156,7 @@ func halfPipe(src net.Conn, dst net.Conn,
 		nr, er := src.Read(buf)
 		if er != nil {
 			if nr > len(buf) {
-				log.Errorf("unexpected read len error - up:%t (%dB): %s", isUpload, nr, err)
+				log.Errorf("unexpected read len error - up:%t (%dB): %s", isUpload, nr, er)
 			}
 			if e := generalizeErr(er); e != nil {
 				if isUpload {

--- a/pkg/station/lib/proxies.go
+++ b/pkg/station/lib/proxies.go
@@ -155,6 +155,9 @@ func halfPipe(src net.Conn, dst net.Conn,
 	for {
 		nr, er := src.Read(buf)
 		if er != nil {
+			if nr > len(buf) {
+				log.Errorf("unexpected read len error - up:%t (%dB): %s", isUpload, nr, err)
+			}
 			if e := generalizeErr(er); e != nil {
 				if isUpload {
 					stats.ClientConnErr = e.Error()
@@ -165,6 +168,10 @@ func halfPipe(src net.Conn, dst net.Conn,
 			break
 		}
 		if nr > 0 {
+			if nr > len(buf) && er == nil {
+				log.Errorf("unexpected read len error - up:%t (%dB)", isUpload, nr)
+			}
+
 			toWrite := int(math.Min(float64(len(buf)), float64(nr)))
 			nw, ew := dst.Write(buf[:toWrite])
 

--- a/pkg/station/lib/proxies_test.go
+++ b/pkg/station/lib/proxies_test.go
@@ -288,7 +288,7 @@ func TestHalfpipeLargeWrite(t *testing.T) {
 
 	go func() {
 		b := make([]byte, 1024)
-		io.CopyBuffer(io.Discard, covertCovert, b)
+		_, _ = io.CopyBuffer(io.Discard, covertCovert, b)
 	}()
 
 	go halfPipe(clientStation, stationCovert, &wg, logger, "Up "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})

--- a/pkg/station/lib/proxies_test.go
+++ b/pkg/station/lib/proxies_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	mrand "math/rand"
 	"net"
 	"os"
 	"sync"
@@ -262,6 +263,41 @@ func TestHalfpipeDeadlineActual(t *testing.T) {
 
 	// covertStation will Timeout and send an EOF to covertCovert
 	require.ErrorIs(t, io.EOF, serverErr)
+
+	clientClient.Close()
+	covertCovert.Close()
+	wg.Wait()
+}
+
+// Test large writes and what happens when short write error is hit
+func TestHalfpipeLargeWrite(t *testing.T) {
+
+	inbuf := make([]byte, 32805)
+
+	n, err := mrand.Read(inbuf)
+	require.Nil(t, err)
+	require.Equal(t, len(inbuf), n)
+
+	clientClient, clientStation := net.Pipe()
+	stationCovert, covertCovert := net.Pipe()
+
+	logger := log.New(os.Stdout, "", 0)
+	logger.SetLevel(log.TraceLevel)
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		b := make([]byte, 1024)
+		io.CopyBuffer(io.Discard, covertCovert, b)
+	}()
+
+	go halfPipe(clientStation, stationCovert, &wg, logger, "Up "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
+	go halfPipe(stationCovert, clientStation, &wg, logger, "Down "+"XXXXXX", &tunnelStats{proxyStats: getProxyStats()})
+
+	nw, err := clientClient.Write(inbuf)
+	require.Nil(t, err)
+
+	require.Equal(t, len(inbuf), nw)
 
 	clientClient.Close()
 	covertCovert.Close()

--- a/scripts/install_pfring.sh
+++ b/scripts/install_pfring.sh
@@ -33,7 +33,7 @@ else
 	make install
 	mkdir -p /local/include/linux/
 	cp linux/pf_ring.h /usr/local/include/linux/
-	cd ..
-	make
+	cd ../userland
+	make all
 	make install
 fi


### PR DESCRIPTION
It is somehow possible for the proxy to make an out of bounds access in the halfpipe slice creation. It is not clear how this is possible since we are calling read with a fixed size buffer, but the issue seems to have occurred on several stations independently.

```log
12:44:51 conjure: panic: runtime error: slice bounds out of range [:32804] with capacity 32768
12:44:51 conjure: goroutine 192061459 [running]:
12:44:51 conjure: github.com/refraction-networking/conjure/pkg/station/lib.halfPipe({0xbcdb28, 0xc003cac040}, {0xbcd618, 0xc0164223c0}, 0xc009744520, 0xc000246b20, {0xc01682a8b8, 0x13}, 0xc005a89680)
12:44:51 conjure:         /opt/conjure/conjure/pkg/station/lib/proxies.go:158 +0x870
12:44:51 conjure: created by github.com/refraction-networking/conjure/pkg/station/lib.Proxy in goroutine 192061268
12:44:51 conjure:         /opt/conjure/conjure/pkg/station/lib/proxies.go:266 +0x5a5
``` 

The offending code is [here](https://github.com/refraction-networking/conjure/blob/master/pkg/station/lib/proxies.go#L153-L170)

```go
	buf := make([]byte, 32*1024)
	for {
		nr, er := src.Read(buf)
		if nr > 0 {
			nw, ew := dst.Write(buf[0:nr])

			// Update stats:
			stats.addBytes(int64(nw), isUpload)
			if isUpload {
				Stat().AddBytesUp(int64(nw))
			} else {
				Stat().AddBytesDown(int64(nw))
			}

			if ew == nil && nw != nr {
				ew = io.ErrShortWrite
			}
``` 

This PR provides a simple change that:
1. checks the error before accessing the buffer
2. ensures that the slice size is never larger than the buffer size.

**Update:** while this PR prevents crashes the core issue was the incorrect length returned from reads in the dtls heartbeat package. This was fixed in #256, however this PR is still relevant for stability in case of unreliable readers in the future.

---
PR #255 implements a more complex, but potentially more complete solution