### PR TITLE
Use ECDSALegacy to generate keys

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -2,25 +2,23 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-
   build:
     name: Build and Test using Golang ${{ matrix.go-version }}
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x, stable]
+        go-version: [1.19.x, 1.20.x, stable]
 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           path: go/src/github.com/refraction-networking/conjure
-
 
       - name: Install deps
         run: |

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,8 @@ require (
 )
 
 require (
+	filippo.io/bigmod v0.0.1 // indirect
+	filippo.io/keygen v0.0.0-20230306160926-5201437acf8e // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+filippo.io/bigmod v0.0.1 h1:OaEqDr3gEbofpnHbGqZweSL/bLMhy1pb54puiCDeuOA=
+filippo.io/bigmod v0.0.1/go.mod h1:KyzqAbH7bRH6MOuOF1TPfUjvLoi0mRF2bIyD2ouRNQI=
+filippo.io/keygen v0.0.0-20230306160926-5201437acf8e h1:+xwUCyMiCWKWsI0RowhzB4sngpUdMHgU6lLuWJCX5Dg=
+filippo.io/keygen v0.0.0-20230306160926-5201437acf8e/go.mod h1:ZGSiF/b2hd6MRghF/cid0vXw8pXykRTmIu+JSPw/NCQ=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=

--- a/pkg/dtls/heartbeat_test.go
+++ b/pkg/dtls/heartbeat_test.go
@@ -131,7 +131,7 @@ func TestHeartbeatReadWrite(t *testing.T) {
 	sent := 0
 	toSend := []byte("testtt")
 	sendTimes := 3
-	sleepInterval := conf.Interval / 2
+	sleepInterval := conf.Interval/2 + 100*time.Millisecond
 	var wg sync.WaitGroup
 
 	ctx, cancel := context.WithTimeout(context.Background(), sleepInterval*5+sleepInterval/2)

--- a/pkg/dtls/seedtocert.go
+++ b/pkg/dtls/seedtocert.go
@@ -16,6 +16,7 @@ import (
 	"math/big"
 	"time"
 
+	"filippo.io/keygen"
 	"github.com/pion/dtls/v2/pkg/protocol/handshake"
 	"golang.org/x/crypto/hkdf"
 )
@@ -36,7 +37,7 @@ func clientHelloRandomFromSeed(seed []byte) ([handshake.RandomBytesLength]byte, 
 func getPrivkey(seed []byte) (*ecdsa.PrivateKey, error) {
 	randSource := hkdf.New(sha256.New, seed, nil, nil)
 
-	privkey, err := ecdsa.GenerateKey(elliptic.P256(), &Not1Reader{r: randSource})
+	privkey, err := keygen.ECDSALegacy(elliptic.P256(), randSource)
 	if err != nil {
 		return &ecdsa.PrivateKey{}, err
 	}


### PR DESCRIPTION
To keep compatibility with go 1.19 and in future versions. 