### PR TITLE
Fix deadlock by buffering acceptCh channel

### DIFF
--- a/pkg/dtls/listener.go
+++ b/pkg/dtls/listener.go
@@ -217,7 +217,7 @@ func (l *Listener) registerChannel(connID [handshake.RandomBytesLength]byte) (<-
 		return nil, fmt.Errorf("seed already registered")
 	}
 
-	connChan := make(chan net.Conn)
+	connChan := make(chan net.Conn, 1)
 	l.connMap[connID] = connChan
 
 	return connChan, nil


### PR DESCRIPTION
The DTLS listener can run into deadlock [here](https://github.com/refraction-networking/conjure/blob/master/pkg/dtls/listener.go#L65-L74) due to being stuck at `acceptCh <- newDTLSConn` and not releasing the mutex. 