### PR TITLE
Adding a new option to captool to exclude subnets traffic from being captured

### DIFF
--- a/util/captool/src/packet_handler.rs
+++ b/util/captool/src/packet_handler.rs
@@ -176,20 +176,16 @@ impl PacketHandler {
             return AnonymizeTypes::None;
         }
 
+	for excepted_subnet in &self.excepted_subnets {
+	    if excepted_subnet.contains(&src)  ||  excepted_subnet.contains(&dst) {
+		return AnonymizeTypes::None;
+	    }
+	}
+        
         for target_subnet in &self.target_subnets {
             if target_subnet.contains(&src) {
-		for excepted_subnet in &self.excepted_subnets {
-		    if excepted_subnet.contains(&src) {
-			return AnonymizeTypes::None;
-		    }
-		}
                 return AnonymizeTypes::Download;
             } else if target_subnet.contains(&dst) {
-		for excepted_subnet in &self.excepted_subnets {
-                    if excepted_subnet.contains(&dst) {
-                        return AnonymizeTypes::None;
-                    }
-                }
                 return AnonymizeTypes::Upload;
             }
         }


### PR DESCRIPTION
./captool ...... --except "subnets_list"

An optional arg to allow for the exclusion of certain subnets from traffic capturing. This is useful when trying to avoid capturing station-covert flows when the station IP is within the target subnets specified by -t arg.