### PR TITLE
Make specific version selector functions public

### DIFF
--- a/pkg/phantoms/compat.go
+++ b/pkg/phantoms/compat.go
@@ -57,12 +57,12 @@ func (sc *SubnetConfig) getSubnetsVarint(seed []byte, weighted bool) ([]*phantom
 	return out, nil
 }
 
-// selectPhantomImplVarint - select an ip address from the list of subnets
+// SelectPhantomImplVarint - select an ip address from the list of subnets
 // associated with the specified generation by constructing a set of start and
 // end values for the high and low values in each allocation. The random number
 // is then bound between the global min and max of that set. This ensures that
 // addresses are chosen based on the number of addresses in the subnet.
-func selectPhantomImplVarint(seed []byte, subnets []*phantomNet) (*PhantomIP, error) {
+func SelectPhantomImplVarint(seed []byte, subnets []*phantomNet) (*PhantomIP, error) {
 	type idNet struct {
 		min, max big.Int
 		net      *phantomNet
@@ -129,9 +129,9 @@ func selectPhantomImplVarint(seed []byte, subnets []*phantomNet) (*PhantomIP, er
 	return result, nil
 }
 
-// selectPhantomImplV0 implements support for the legacy (buggy) client phantom
+// SelectPhantomImplV0 implements support for the legacy (buggy) client phantom
 // address selection algorithm.
-func selectPhantomImplV0(seed []byte, subnets []*phantomNet) (*PhantomIP, error) {
+func SelectPhantomImplV0(seed []byte, subnets []*phantomNet) (*PhantomIP, error) {
 
 	addressTotal := big.NewInt(0)
 

--- a/pkg/phantoms/phantom_selector.go
+++ b/pkg/phantoms/phantom_selector.go
@@ -92,7 +92,7 @@ func getSubnetsHkdf(sc genericSubnetConfig, seed []byte, weighted bool) ([]*phan
 	return out, nil
 }
 
-func selectPhantomImplHkdf(seed []byte, subnets []*phantomNet) (*PhantomIP, error) {
+func SelectPhantomImplHkdf(seed []byte, subnets []*phantomNet) (*PhantomIP, error) {
 	type idNet struct {
 		min, max big.Int
 		net      *phantomNet

--- a/pkg/phantoms/phantoms.go
+++ b/pkg/phantoms/phantoms.go
@@ -97,7 +97,7 @@ func parseSubnet(phantomSubnet string) (*net.IPNet, error) {
 // bound between the global min and max of that set. This ensures that
 // addresses are chosen based on the number of addresses in the subnet.
 func selectIPAddr(seed []byte, subnets []*phantomNet) (*PhantomIP, error) {
-	return selectPhantomImplHkdf(seed, subnets)
+	return SelectPhantomImplHkdf(seed, subnets)
 }
 
 // SelectPhantom - select one phantom IP address based on shared secret

--- a/pkg/phantoms/station_phantoms.go
+++ b/pkg/phantoms/station_phantoms.go
@@ -158,14 +158,14 @@ func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer ui
 	// handle legacy clientLibVersions for selecting phantoms.
 	if clientLibVer < core.PhantomSelectionMinGeneration {
 		// Version 0
-		ip, err := selectPhantomImplV0(seed, genSubnets)
+		ip, err := SelectPhantomImplV0(seed, genSubnets)
 		if err != nil {
 			return nil, err
 		}
 		return ip, nil
 	} else if clientLibVer < core.PhantomHkdfMinVersion {
 		// Version 1
-		ip, err := selectPhantomImplVarint(seed, genSubnets)
+		ip, err := SelectPhantomImplVarint(seed, genSubnets)
 		if err != nil {
 			return nil, err
 		}
@@ -173,7 +173,7 @@ func (p *PhantomIPSelector) Select(seed []byte, generation uint, clientLibVer ui
 	}
 
 	// Version 2+
-	ip, err := selectPhantomImplHkdf(seed, genSubnets)
+	ip, err := SelectPhantomImplHkdf(seed, genSubnets)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change makes the selectPhantom*() functions public (e.g. SelectPhantom*() ), which is needed by the gen-bias tool in the gotapdance repo. Since we refactored this and moved it to the station repo, we'll either need to move the gen-bias tool here or make this change to be able to generate the bias for arbitrary client versions.