### PR TITLE
Support for experimental reg overrides

### DIFF
--- a/cmd/registration-server/main.go
+++ b/cmd/registration-server/main.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ed25519"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"os/signal"
 	"strconv"
@@ -33,20 +34,33 @@ type regServer interface {
 
 // config defines the variables and options from the toml config file
 type config struct {
-	DNSListenAddr      string   `toml:"dns_listen_addr"`
-	Domain             string   `toml:"domain"`
-	DNSPrivkeyPath     string   `toml:"dns_private_key_path"`
-	APIPort            uint16   `toml:"api_port"`
-	ZMQAuthVerbose     bool     `toml:"zmq_auth_verbose"`
-	ZMQAuthType        string   `toml:"zmq_auth_type"`
-	ZMQPort            uint16   `toml:"zmq_port"`
-	ZMQBindAddr        string   `toml:"zmq_bind_addr"`
-	ZMQPrivateKeyPath  string   `toml:"zmq_privkey_path"`
-	StationPublicKeys  []string `toml:"station_pubkeys"`
-	ClientConfPath     string   `toml:"clientconf_path"`
-	latestClientConf   *pb.ClientConf
-	LogLevel           string `toml:"log_level"`
-	LogMetricsInterval uint16 `toml:"log_metrics_interval"`
+	DNSListenAddr          string   `toml:"dns_listen_addr"`
+	Domain                 string   `toml:"domain"`
+	DNSPrivkeyPath         string   `toml:"dns_private_key_path"`
+	APIPort                uint16   `toml:"api_port"`
+	ZMQAuthVerbose         bool     `toml:"zmq_auth_verbose"`
+	ZMQAuthType            string   `toml:"zmq_auth_type"`
+	ZMQPort                uint16   `toml:"zmq_port"`
+	ZMQBindAddr            string   `toml:"zmq_bind_addr"`
+	ZMQPrivateKeyPath      string   `toml:"zmq_privkey_path"`
+	StationPublicKeys      []string `toml:"station_pubkeys"`
+	ClientConfPath         string   `toml:"clientconf_path"`
+	latestClientConf       *pb.ClientConf
+	LogLevel               string                `toml:"log_level"`
+	LogMetricsInterval     uint16                `toml:"log_metrics_interval"`
+	EnforceSubnetOverrides bool                  `toml:"enforce_subnet_overrides"`
+	OverrideSubnets        []regprocessor.Subnet `toml:"override_subnets"`
+	ExclusionsFromOverride []regprocessor.Subnet `toml:"excluded_subnets_from_overrides"`
+}
+
+// UnmarshalText makes CIDR compatible with TOML decoding
+func (n *regprocessor.ipnet) UnmarshalText(text []byte) error {
+	_, cidr, err := net.ParseCIDR(string(text))
+	if err != nil {
+		return err
+	}
+	n.IPNet = cidr
+	return nil
 }
 
 var defaultTransports = map[pb.TransportType]lib.Transport{
@@ -192,9 +206,9 @@ func main() {
 
 	switch conf.ZMQAuthType {
 	case "CURVE":
-		processor, err = regprocessor.NewRegProcessor(conf.ZMQBindAddr, conf.ZMQPort, zmqPrivkey, conf.ZMQAuthVerbose, conf.StationPublicKeys, metrics)
+		processor, err = regprocessor.NewRegProcessor(conf.ZMQBindAddr, conf.ZMQPort, zmqPrivkey, conf.ZMQAuthVerbose, conf.StationPublicKeys, metrics, conf.EnforceSubnetOverrides, conf.OverrideSubnets, conf.ExclusionsFromOverride)
 	case "NULL":
-		processor, err = regprocessor.NewRegProcessorNoAuth(conf.ZMQBindAddr, conf.ZMQPort, metrics)
+		processor, err = regprocessor.NewRegProcessorNoAuth(conf.ZMQBindAddr, conf.ZMQPort, metrics, conf.EnforceSubnetOverrides, conf.OverrideSubnets, conf.ExclusionsFromOverride)
 	default:
 		log.Fatalf("Unknown ZMQ auth type: %s", conf.ZMQAuthType)
 	}

--- a/cmd/registration-server/main.go
+++ b/cmd/registration-server/main.go
@@ -33,23 +33,25 @@ type regServer interface {
 
 // config defines the variables and options from the toml config file
 type config struct {
-	DNSListenAddr          string   `toml:"dns_listen_addr"`
-	Domain                 string   `toml:"domain"`
-	DNSPrivkeyPath         string   `toml:"dns_private_key_path"`
-	APIPort                uint16   `toml:"api_port"`
-	ZMQAuthVerbose         bool     `toml:"zmq_auth_verbose"`
-	ZMQAuthType            string   `toml:"zmq_auth_type"`
-	ZMQPort                uint16   `toml:"zmq_port"`
-	ZMQBindAddr            string   `toml:"zmq_bind_addr"`
-	ZMQPrivateKeyPath      string   `toml:"zmq_privkey_path"`
-	StationPublicKeys      []string `toml:"station_pubkeys"`
-	ClientConfPath         string   `toml:"clientconf_path"`
-	latestClientConf       *pb.ClientConf
-	LogLevel               string                `toml:"log_level"`
-	LogMetricsInterval     uint16                `toml:"log_metrics_interval"`
-	EnforceSubnetOverrides bool                  `toml:"enforce_subnet_overrides"`
-	OverrideSubnets        []regprocessor.Subnet `toml:"override_subnets"`
-	ExclusionsFromOverride []regprocessor.Subnet `toml:"excluded_subnets_from_overrides"`
+	DNSListenAddr              string   `toml:"dns_listen_addr"`
+	Domain                     string   `toml:"domain"`
+	DNSPrivkeyPath             string   `toml:"dns_private_key_path"`
+	APIPort                    uint16   `toml:"api_port"`
+	ZMQAuthVerbose             bool     `toml:"zmq_auth_verbose"`
+	ZMQAuthType                string   `toml:"zmq_auth_type"`
+	ZMQPort                    uint16   `toml:"zmq_port"`
+	ZMQBindAddr                string   `toml:"zmq_bind_addr"`
+	ZMQPrivateKeyPath          string   `toml:"zmq_privkey_path"`
+	StationPublicKeys          []string `toml:"station_pubkeys"`
+	ClientConfPath             string   `toml:"clientconf_path"`
+	latestClientConf           *pb.ClientConf
+	LogLevel                   string                `toml:"log_level"`
+	LogMetricsInterval         uint16                `toml:"log_metrics_interval"`
+	EnforceSubnetOverrides     bool                  `toml:"enforce_subnet_overrides"`
+	PrcntMinConnsToOverride    float64               `toml:"prcnt_min_conns_to_override"`
+	PrcntPrefixConnsToOverride float64               `toml:"prcnt_prefix_conns_to_override"`
+	OverrideSubnets            []regprocessor.Subnet `toml:"override_subnets"`
+	ExclusionsFromOverride     []regprocessor.Subnet `toml:"excluded_subnets_from_overrides"`
 }
 
 var defaultTransports = map[pb.TransportType]lib.Transport{
@@ -195,9 +197,9 @@ func main() {
 
 	switch conf.ZMQAuthType {
 	case "CURVE":
-		processor, err = regprocessor.NewRegProcessor(conf.ZMQBindAddr, conf.ZMQPort, zmqPrivkey, conf.ZMQAuthVerbose, conf.StationPublicKeys, metrics, conf.EnforceSubnetOverrides, conf.OverrideSubnets, conf.ExclusionsFromOverride)
+		processor, err = regprocessor.NewRegProcessor(conf.ZMQBindAddr, conf.ZMQPort, zmqPrivkey, conf.ZMQAuthVerbose, conf.StationPublicKeys, metrics, conf.EnforceSubnetOverrides, conf.OverrideSubnets, conf.ExclusionsFromOverride, conf.PrcntMinConnsToOverride, conf.PrcntPrefixConnsToOverride)
 	case "NULL":
-		processor, err = regprocessor.NewRegProcessorNoAuth(conf.ZMQBindAddr, conf.ZMQPort, metrics, conf.EnforceSubnetOverrides, conf.OverrideSubnets, conf.ExclusionsFromOverride)
+		processor, err = regprocessor.NewRegProcessorNoAuth(conf.ZMQBindAddr, conf.ZMQPort, metrics, conf.EnforceSubnetOverrides, conf.OverrideSubnets, conf.ExclusionsFromOverride, conf.PrcntMinConnsToOverride, conf.PrcntPrefixConnsToOverride)
 	default:
 		log.Fatalf("Unknown ZMQ auth type: %s", conf.ZMQAuthType)
 	}

--- a/cmd/registration-server/main.go
+++ b/cmd/registration-server/main.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ed25519"
 	"flag"
 	"fmt"
-	"net"
 	"os"
 	"os/signal"
 	"strconv"
@@ -51,19 +50,6 @@ type config struct {
 	EnforceSubnetOverrides bool                  `toml:"enforce_subnet_overrides"`
 	OverrideSubnets        []regprocessor.Subnet `toml:"override_subnets"`
 	ExclusionsFromOverride []regprocessor.Subnet `toml:"excluded_subnets_from_overrides"`
-}
-
-// backing non-local type with local definition
-type ipnet regprocessor.Ipnet
-
-// UnmarshalText makes CIDR compatible with TOML decoding
-func (n *ipnet) UnmarshalText(text []byte) error {
-	_, cidr, err := net.ParseCIDR(string(text))
-	if err != nil {
-		return err
-	}
-	n.IPNet = cidr
-	return nil
 }
 
 var defaultTransports = map[pb.TransportType]lib.Transport{

--- a/cmd/registration-server/main.go
+++ b/cmd/registration-server/main.go
@@ -33,25 +33,25 @@ type regServer interface {
 
 // config defines the variables and options from the toml config file
 type config struct {
-	DNSListenAddr              string   `toml:"dns_listen_addr"`
-	Domain                     string   `toml:"domain"`
-	DNSPrivkeyPath             string   `toml:"dns_private_key_path"`
-	APIPort                    uint16   `toml:"api_port"`
-	ZMQAuthVerbose             bool     `toml:"zmq_auth_verbose"`
-	ZMQAuthType                string   `toml:"zmq_auth_type"`
-	ZMQPort                    uint16   `toml:"zmq_port"`
-	ZMQBindAddr                string   `toml:"zmq_bind_addr"`
-	ZMQPrivateKeyPath          string   `toml:"zmq_privkey_path"`
-	StationPublicKeys          []string `toml:"station_pubkeys"`
-	ClientConfPath             string   `toml:"clientconf_path"`
-	latestClientConf           *pb.ClientConf
-	LogLevel                   string                `toml:"log_level"`
-	LogMetricsInterval         uint16                `toml:"log_metrics_interval"`
-	EnforceSubnetOverrides     bool                  `toml:"enforce_subnet_overrides"`
-	PrcntMinConnsToOverride    float64               `toml:"prcnt_min_conns_to_override"`
-	PrcntPrefixConnsToOverride float64               `toml:"prcnt_prefix_conns_to_override"`
-	OverrideSubnets            []regprocessor.Subnet `toml:"override_subnets"`
-	ExclusionsFromOverride     []regprocessor.Subnet `toml:"excluded_subnets_from_overrides"`
+	DNSListenAddr             string   `toml:"dns_listen_addr"`
+	Domain                    string   `toml:"domain"`
+	DNSPrivkeyPath            string   `toml:"dns_private_key_path"`
+	APIPort                   uint16   `toml:"api_port"`
+	ZMQAuthVerbose            bool     `toml:"zmq_auth_verbose"`
+	ZMQAuthType               string   `toml:"zmq_auth_type"`
+	ZMQPort                   uint16   `toml:"zmq_port"`
+	ZMQBindAddr               string   `toml:"zmq_bind_addr"`
+	ZMQPrivateKeyPath         string   `toml:"zmq_privkey_path"`
+	StationPublicKeys         []string `toml:"station_pubkeys"`
+	ClientConfPath            string   `toml:"clientconf_path"`
+	latestClientConf          *pb.ClientConf
+	LogLevel                  string                `toml:"log_level"`
+	LogMetricsInterval        uint16                `toml:"log_metrics_interval"`
+	EnforceSubnetOverrides    bool                  `toml:"enforce_subnet_overrides"`
+	PrcntMinRegsToOverride    float64               `toml:"prcnt_min_regs_to_override"`
+	PrcntPrefixRegsToOverride float64               `toml:"prcnt_prefix_regs_to_override"`
+	OverrideSubnets           []regprocessor.Subnet `toml:"override_subnet"`
+	ExclusionsFromOverride    []regprocessor.Subnet `toml:"excluded_subnet_from_overrides"`
 }
 
 var defaultTransports = map[pb.TransportType]lib.Transport{
@@ -197,9 +197,9 @@ func main() {
 
 	switch conf.ZMQAuthType {
 	case "CURVE":
-		processor, err = regprocessor.NewRegProcessor(conf.ZMQBindAddr, conf.ZMQPort, zmqPrivkey, conf.ZMQAuthVerbose, conf.StationPublicKeys, metrics, conf.EnforceSubnetOverrides, conf.OverrideSubnets, conf.ExclusionsFromOverride, conf.PrcntMinConnsToOverride, conf.PrcntPrefixConnsToOverride)
+		processor, err = regprocessor.NewRegProcessor(conf.ZMQBindAddr, conf.ZMQPort, zmqPrivkey, conf.ZMQAuthVerbose, conf.StationPublicKeys, metrics, conf.EnforceSubnetOverrides, conf.OverrideSubnets, conf.ExclusionsFromOverride, conf.PrcntMinRegsToOverride, conf.PrcntPrefixRegsToOverride)
 	case "NULL":
-		processor, err = regprocessor.NewRegProcessorNoAuth(conf.ZMQBindAddr, conf.ZMQPort, metrics, conf.EnforceSubnetOverrides, conf.OverrideSubnets, conf.ExclusionsFromOverride, conf.PrcntMinConnsToOverride, conf.PrcntPrefixConnsToOverride)
+		processor, err = regprocessor.NewRegProcessorNoAuth(conf.ZMQBindAddr, conf.ZMQPort, metrics, conf.EnforceSubnetOverrides, conf.OverrideSubnets, conf.ExclusionsFromOverride, conf.PrcntMinRegsToOverride, conf.PrcntPrefixRegsToOverride)
 	default:
 		log.Fatalf("Unknown ZMQ auth type: %s", conf.ZMQAuthType)
 	}

--- a/cmd/registration-server/main.go
+++ b/cmd/registration-server/main.go
@@ -53,8 +53,11 @@ type config struct {
 	ExclusionsFromOverride []regprocessor.Subnet `toml:"excluded_subnets_from_overrides"`
 }
 
+// backing non-local type with local definition
+type ipnet regprocessor.Ipnet
+
 // UnmarshalText makes CIDR compatible with TOML decoding
-func (n *regprocessor.ipnet) UnmarshalText(text []byte) error {
+func (n *ipnet) UnmarshalText(text []byte) error {
 	_, cidr, err := net.ParseCIDR(string(text))
 	if err != nil {
 		return err

--- a/cmd/registration-server/reg_config.toml
+++ b/cmd/registration-server/reg_config.toml
@@ -45,3 +45,32 @@ bidirectional_api_generation = 957
 
 # Path on disk to the latest ClientConfig file that the station should use
 clientconf_path = "/var/lib/conjure/ClientConf"
+
+# Whether to apply the below subnet overrides to clients bidirectional api registrations
+enforce_subnet_overrides = true
+
+# Percentage of bidirectional api registrations to override per transport
+prcnt_min_regs_to_override = 100
+prcnt_prefix_regs_to_override = 100
+
+# Subnets to use when overriding clients bidirectional api registrations
+[[override_subnet]]
+cidr = "X.X.X.X/32"
+weight = 10.7
+port = 443
+transport = "Min_Transport"
+
+[[override_subnet]]
+cidr = "X.X.X.X/24"
+weight = 10
+port = 80
+transport = "Prefix_Transport"
+prefix_id = 1
+
+# Subnets to refrain from overriding when clients bidirectional api registrations pick a v4 phantom inside them
+[[excluded_subnet_from_overrides]]
+cidr = "X.X.X.X/25"
+# For future features that can exclude subnets according to weight, port, or transport
+weight = 28.7
+port = 80
+transport = "Min_Transport"

--- a/pkg/regserver/regprocessor/auth_test.go
+++ b/pkg/regserver/regprocessor/auth_test.go
@@ -134,7 +134,7 @@ func TestZMQAuth(t *testing.T) {
 	// messages that we expect the station to hear. in production this will be new registrations,
 	// here we don't care about the message contents.
 	go func() {
-		regProcessor, err := newRegProcessor(zmqBindAddr, zmqPort, []byte(zmq.Z85decode(serverPrivkeyZ85)), true, stationPublicKeys)
+		regProcessor, err := newRegProcessor(zmqBindAddr, zmqPort, []byte(zmq.Z85decode(serverPrivkeyZ85)), true, stationPublicKeys, false, nil, nil, 0.0, 0.0)
 		require.Nil(t, err)
 		defer regProcessor.Close()
 		errStation := regProcessor.AddTransport(pb.TransportType_Min, min.Transport{})

--- a/pkg/regserver/regprocessor/regprocessor.go
+++ b/pkg/regserver/regprocessor/regprocessor.go
@@ -487,6 +487,10 @@ func (p *RegProcessor) processBdReq(c2sPayload *pb.C2SWrapper) (*pb.Registration
 		// ignore prior choices and begin experimental overrides for Min and Prefix transports only
 		if transportType == pb.TransportType_Min {
 
+			if p.minOverrideSubnets == nil {
+				// reg_conf.toml does not contain subnet overrides for Min transport
+				return regResp, nil
+			}
 			// TODO: process subnet overrides and pick one according to assigned weights
 
 			ipv4FromRegResponse := uint32ToIPv4(regResp.Ipv4Addr)

--- a/pkg/regserver/regprocessor/regprocessor.go
+++ b/pkg/regserver/regprocessor/regprocessor.go
@@ -181,6 +181,9 @@ func overridePrefix(newRegResp *pb.RegistrationResponse, prefixId prefix.PrefixI
 	newRegResp.DstPort = proto.Uint32(dstPort)
 	// Override Prefix choice and PrefixParam
 	newPrefix, err := prefix.TryFromID(prefixId)
+	if err != nil {
+		return err
+	}
 	var fp = newPrefix.FlushPolicy()
 	var i int32 = int32(newPrefix.ID())
 	newparams := &pb.PrefixTransportParams{}

--- a/pkg/regserver/regprocessor/regprocessor.go
+++ b/pkg/regserver/regprocessor/regprocessor.go
@@ -94,11 +94,11 @@ type RegProcessor struct {
 }
 
 type Subnet struct {
-	CIDR      Ipnet   `toml:"cidr"`
-	Weight    float64 `toml:"weight"`
-	Port      uint32  `toml:"port"`
-	Transport string  `toml:"transport"`
-	PrefixxID int     `toml:"prefix_id"`
+	CIDR      Ipnet           `toml:"cidr"`
+	Weight    float64         `toml:"weight"`
+	Port      uint32          `toml:"port"`
+	Transport string          `toml:"transport"`
+	PrefixId  prefix.PrefixID `toml:"prefix_id"`
 }
 
 type Ipnet struct {
@@ -623,12 +623,12 @@ func (p *RegProcessor) processBdReq(c2sPayload *pb.C2SWrapper) (*pb.Registration
 					}
 
 					//newRegResp := &pb.RegistrationResponse{}
-					var prefixid int
+					var prefixid prefix.PrefixID
 					for i, cumulativeWeight := range p.prefixOverrideSubnetsCumulativeWeights {
 						if randVal < cumulativeWeight {
 							ipNet = p.prefixOverrideSubnets[i].CIDR.IPNet
 							dstPortOverride = p.prefixOverrideSubnets[i].Port
-							prefixid = p.prefixOverrideSubnets[i].PrefixxID
+							prefixid = p.prefixOverrideSubnets[i].PrefixId
 						}
 					}
 

--- a/pkg/regserver/regprocessor/regprocessor.go
+++ b/pkg/regserver/regprocessor/regprocessor.go
@@ -165,7 +165,7 @@ func getRandUint32IPv4(ipNet *net.IPNet) (uint32, error) {
 
 // helper function to get random integers within a range
 func randomInt(x, y uint32) (uint32, error) {
-	rangeSize := y - x + 1
+	rangeSize := y - x
 	// Generate a random number in the range [0, rangeSize)
 	randomNum, err := rand.Int(rand.Reader, big.NewInt(int64(rangeSize)))
 	if err != nil {
@@ -583,10 +583,14 @@ func (p *RegProcessor) processBdReq(c2sPayload *pb.C2SWrapper) (*pb.Registration
 			// do not apply overrides
 			return regResp, nil
 		}
+
+		// random float64 between 0 and 999
 		randNumFloat := float64(num) / 10.0
 
 		var ipNet *net.IPNet
 		var dstPortOverride uint32
+
+		// random float64 between 0 and 1
 		mrand.Seed(time.Now().UnixNano())
 		randVal := mrand.Float64()
 

--- a/pkg/regserver/regprocessor/regprocessor.go
+++ b/pkg/regserver/regprocessor/regprocessor.go
@@ -86,14 +86,14 @@ type RegProcessor struct {
 }
 
 type Subnet struct {
-	CIDR      ipnet   `toml:"cidr"`
+	CIDR      Ipnet   `toml:"cidr"`
 	Weight    float64 `toml:"weight"`
 	Port      int     `toml:"port"`
 	Transport string  `toml:"transport"`
 }
 
 // Custom type to handle CIDR notation in TOML
-type ipnet struct {
+type Ipnet struct {
 	*net.IPNet
 }
 


### PR DESCRIPTION
This PR allows for overriding v4 phantom addresses during the bidi registrations (not overriding transport choices). Operators can specify the desired subnet overrides in the reg_config.toml file in the reg server. A new template for reg_config.toml is updated.