### PR TITLE
Allow client to send public IP in bdapi request

### DIFF
--- a/pkg/regserver/regprocessor/regprocessor.go
+++ b/pkg/regserver/regprocessor/regprocessor.go
@@ -701,8 +701,7 @@ func (p *RegProcessor) processC2SWrapper(c2sPayload *pb.C2SWrapper, clientAddr [
 
 	// If the address that the registration was received from was NOT set in the
 	// C2SWrapper set it here to the source address of the request.
-	if (c2sPayload.GetRegistrationAddress() == nil ||
-		c2sPayload.GetRegistrationSource() == regMethod) && clientAddr != nil {
+	if c2sPayload.GetRegistrationAddress() == nil && clientAddr != nil {
 		payload.RegistrationAddress = clientAddr
 	} else {
 		payload.RegistrationAddress = c2sPayload.GetRegistrationAddress()

--- a/src/elligator.rs
+++ b/src/elligator.rs
@@ -44,9 +44,8 @@ pub fn extract_payloads_multiple_keys(
             return Ok(payload_elements);
         }
     }
-    Err(Box::new(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "No secret keys worked",
+    Err(Box::new(std::io::Error::other(
+        "No secret keys worked".to_string(),
     )))
 }
 


### PR DESCRIPTION
This change adds an IP field to bidirectional API registration requests and prioritizes this field, if it exists, over the station-determined remote address. Clients can use STUN to determine their public IP address.

This feature is particularly useful for domain-fronted connections over CDNs that mask the client IP for privacy reasons. Closes https://github.com/refraction-networking/conjure/issues/286

The one thing I wasn't sure about was the purpose of the condition that I removed from regprocessor.go:
```golang
c2sPayload.GetRegistrationSource() == regMethod
```
I assume this is here for some backwards compatability reasons. I couldn't see a reason to not remove it, but I might have missed something.